### PR TITLE
Add SwiftUI client implementation for sprinkler controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # SprinklerApp
-Sprinkler System on Raspberry Pi
+
+Sprinkler System on Raspberry Pi.
+
+## iOS Client Project Setup
+
+An accompanying native iOS app should be created in Xcode by the integrator. **Do not generate the Xcode project from this repository.** Instead, create a new SwiftUI iOS 16+ project in Xcode and configure it according to the design and networking requirements documented in the product brief. Once the project shell exists, bring the Swift source files and configuration described in the brief into that Xcode workspace manually.
+
+Key reminders when setting up the Xcode project:
+
+- Ensure App Transport Security allows local network loads (e.g., set `NSAllowsArbitraryLoadsInLocalNetworks` to `YES`).
+- Target iOS 16 or later.
+- Add the Swift packages or dependencies required by the client code during Xcode configuration.
+- Store the Target IP in `UserDefaults` and wire the networking stack to respect that setting.
+
+Any additional app configuration should also be handled directly within Xcode by the integrator after creating the project.
+
+## SwiftUI Client Code Layout
+
+The `SprinklerMobile` folder contains the SwiftUI source files, models, and configuration required for the native iOS application. After creating the Xcode project, copy these files into your project (preserving the folder grouping if desired) and add them to the target.
+
+```
+SprinklerMobile/
+  SprinklerMobileApp.swift        // App entry point and tab navigation
+  Models/                         // Codable DTOs matching the Raspberry Pi API
+  Networking/                     // HTTP client, API client, and error types
+  State/                          // ObservableObject stores for app state & settings
+  Utils/                          // Validation helpers and toast presentation
+  Views/                          // SwiftUI views for Dashboard, Schedules, Settings
+  Resources/Info.plist            // ATS snippet allowing local network HTTP
+```
+
+The app is organized into three primary tabs (Dashboard, Schedules, Settings) and communicates exclusively with the existing Raspberry Pi HTTP endpoints. Update the target IP address from the Settings tab to point at the controller on your LAN, then build and run the project from Xcode to interact with the sprinkler system.

--- a/SprinklerMobile/Models/PinDTO.swift
+++ b/SprinklerMobile/Models/PinDTO.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct PinDTO: Codable, Identifiable, Hashable {
+    var id: Int { pin }
+
+    let pin: Int
+    var name: String?
+    var isActive: Bool?
+    var isEnabled: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case pin
+        case name
+        case isActive = "is_active"
+        case isEnabled = "is_enabled"
+    }
+}

--- a/SprinklerMobile/Models/RainDTO.swift
+++ b/SprinklerMobile/Models/RainDTO.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct RainDTO: Codable, Equatable {
+    let isActive: Bool?
+    let endsAt: Date?
+    let durationHours: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case isActive = "is_active"
+        case endsAt = "ends_at"
+        case durationHours = "duration_hours"
+    }
+}

--- a/SprinklerMobile/Models/ScheduleDTO.swift
+++ b/SprinklerMobile/Models/ScheduleDTO.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct ScheduleDTO: Codable, Identifiable, Hashable {
+    let id: String
+    let name: String?
+    let durationMinutes: Int?
+    let startTime: String?
+    let days: [String]?
+    let isEnabled: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case durationMinutes = "duration"
+        case startTime = "start_time"
+        case days
+        case isEnabled = "is_enabled"
+    }
+}

--- a/SprinklerMobile/Models/ScheduleGroupDTO.swift
+++ b/SprinklerMobile/Models/ScheduleGroupDTO.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct ScheduleGroupDTO: Codable, Identifiable, Hashable {
+    let id: String
+    let name: String?
+    let isActive: Bool?
+    let scheduleIds: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case isActive = "is_active"
+        case scheduleIds = "schedule_ids"
+    }
+}

--- a/SprinklerMobile/Models/StatusDTO.swift
+++ b/SprinklerMobile/Models/StatusDTO.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct StatusDTO: Codable {
+    let pins: [PinDTO]?
+    let schedules: [ScheduleDTO]?
+    let scheduleGroups: [ScheduleGroupDTO]?
+    let rain: RainDTO?
+    let version: String?
+    let lastUpdated: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case pins
+        case schedules
+        case scheduleGroups = "schedule_groups"
+        case rain
+        case version
+        case lastUpdated = "last_updated"
+    }
+}

--- a/SprinklerMobile/Networking/APIClient.swift
+++ b/SprinklerMobile/Networking/APIClient.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+actor APIClient {
+    private var baseURL: URL?
+    private let httpClient: HTTPClient
+
+    init(baseURL: URL? = nil, httpClient: HTTPClient = HTTPClient()) {
+        self.baseURL = baseURL
+        self.httpClient = httpClient
+    }
+
+    func updateBaseURL(_ url: URL?) {
+        self.baseURL = url
+    }
+
+    func fetchStatus() async throws -> StatusDTO {
+        let url = try makeURL(path: "/api/status")
+        return try await httpClient.request(url: url)
+    }
+
+    func fetchRain() async throws -> RainDTO {
+        let url = try makeURL(path: "/api/rain")
+        return try await httpClient.request(url: url)
+    }
+
+    func setRain(isActive: Bool, durationHours: Int?) async throws {
+        let url = try makeURL(path: "/api/rain")
+        struct RainPayload: Encodable {
+            let active: Bool
+            let hours: Int?
+
+            enum CodingKeys: String, CodingKey {
+                case active = "active"
+                case hours = "hours"
+            }
+        }
+
+        let payload = RainPayload(active: isActive, hours: durationHours)
+        _ = try await httpClient.request(url: url,
+                                         method: .post,
+                                         body: payload,
+                                         fallbackToEmptyBody: true,
+                                         decode: EmptyResponse.self)
+    }
+
+    func setPin(_ pin: Int, on: Bool) async throws {
+        let path = "/api/pin/\(pin)/\(on ? "on" : "off")"
+        let url = try makeURL(path: path)
+        _ = try await httpClient.request(url: url,
+                                         method: .post,
+                                         fallbackToEmptyBody: true,
+                                         decode: EmptyResponse.self)
+    }
+
+    func renamePin(_ pin: Int, name: String) async throws {
+        let url = try makeURL(path: "/api/pin/\(pin)/name")
+        struct RenamePayload: Encodable { let name: String }
+        let payload = RenamePayload(name: name)
+        _ = try await httpClient.request(url: url,
+                                         method: .post,
+                                         body: payload,
+                                         fallbackToEmptyBody: false,
+                                         decode: EmptyResponse.self)
+    }
+
+    func reorderPins(_ pinOrder: [Int]) async throws {
+        let url = try makeURL(path: "/api/pins/reorder")
+        _ = try await httpClient.request(url: url,
+                                         method: .post,
+                                         body: pinOrder,
+                                         fallbackToEmptyBody: false,
+                                         decode: EmptyResponse.self)
+    }
+
+    func createSchedule(_ schedule: ScheduleWritePayload) async throws {
+        let url = try makeURL(path: "/api/schedule")
+        _ = try await httpClient.request(url: url,
+                                         method: .post,
+                                         body: schedule,
+                                         fallbackToEmptyBody: false,
+                                         decode: EmptyResponse.self)
+    }
+
+    func updateSchedule(id: String, schedule: ScheduleWritePayload) async throws {
+        let url = try makeURL(path: "/api/schedule/\(id)")
+        _ = try await httpClient.request(url: url,
+                                         method: .post,
+                                         body: schedule,
+                                         fallbackToEmptyBody: false,
+                                         decode: EmptyResponse.self)
+    }
+
+    func deleteSchedule(id: String) async throws {
+        let url = try makeURL(path: "/api/schedule/\(id)")
+        _ = try await httpClient.request(url: url,
+                                         method: .delete,
+                                         decode: EmptyResponse.self)
+    }
+
+    func reorderSchedules(_ scheduleIds: [String]) async throws {
+        let url = try makeURL(path: "/api/schedules/reorder")
+        _ = try await httpClient.request(url: url,
+                                         method: .post,
+                                         body: scheduleIds,
+                                         fallbackToEmptyBody: false,
+                                         decode: EmptyResponse.self)
+    }
+
+    func fetchScheduleGroups() async throws -> [ScheduleGroupDTO] {
+        let url = try makeURL(path: "/api/schedule-groups")
+        return try await httpClient.request(url: url)
+    }
+
+    func createScheduleGroup(name: String) async throws {
+        let url = try makeURL(path: "/api/schedule-groups")
+        struct GroupPayload: Encodable { let name: String }
+        _ = try await httpClient.request(url: url,
+                                         method: .post,
+                                         body: GroupPayload(name: name),
+                                         fallbackToEmptyBody: false,
+                                         decode: EmptyResponse.self)
+    }
+
+    func selectScheduleGroup(id: String) async throws {
+        let url = try makeURL(path: "/api/schedule-groups/select")
+        struct SelectPayload: Encodable { let id: String }
+        _ = try await httpClient.request(url: url,
+                                         method: .post,
+                                         body: SelectPayload(id: id),
+                                         fallbackToEmptyBody: false,
+                                         decode: EmptyResponse.self)
+    }
+
+    func addAllToGroup(id: String) async throws {
+        let url = try makeURL(path: "/api/schedule-groups/\(id)/add-all")
+        _ = try await httpClient.request(url: url,
+                                         method: .post,
+                                         fallbackToEmptyBody: true,
+                                         decode: EmptyResponse.self)
+    }
+
+    func deleteScheduleGroup(id: String) async throws {
+        let url = try makeURL(path: "/api/schedule-groups/\(id)")
+        _ = try await httpClient.request(url: url,
+                                         method: .delete,
+                                         decode: EmptyResponse.self)
+    }
+
+    private func makeURL(path: String) throws -> URL {
+        guard let baseURL else { throw APIError.invalidURL }
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw APIError.invalidURL
+        }
+        components.path = path
+        guard let url = components.url else { throw APIError.invalidURL }
+        return url
+    }
+}
+
+struct ScheduleWritePayload: Encodable {
+    var name: String?
+    var durationMinutes: Int?
+    var startTime: String?
+    var days: [String]?
+    var isEnabled: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case durationMinutes = "duration"
+        case startTime = "start_time"
+        case days
+        case isEnabled = "is_enabled"
+    }
+}

--- a/SprinklerMobile/Networking/APIError.swift
+++ b/SprinklerMobile/Networking/APIError.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum APIError: Error, LocalizedError, Equatable {
+    case invalidURL
+    case requestFailed(Int)
+    case decodingFailed
+    case unreachable
+    case invalidResponse
+    case validationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL provided."
+        case .requestFailed(let status):
+            return "Request failed with status code \(status)."
+        case .decodingFailed:
+            return "Failed to decode the server response."
+        case .unreachable:
+            return "Unable to reach the sprinkler controller."
+        case .invalidResponse:
+            return "The server returned an unexpected response."
+        case .validationFailed(let message):
+            return message
+        }
+    }
+}

--- a/SprinklerMobile/Networking/EmptyResponse.swift
+++ b/SprinklerMobile/Networking/EmptyResponse.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+struct EmptyResponse: Decodable {}

--- a/SprinklerMobile/Networking/HTTPClient.swift
+++ b/SprinklerMobile/Networking/HTTPClient.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+final class HTTPClient {
+    private let session: URLSession
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+
+    init(session: URLSession = .shared) {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 8
+        configuration.timeoutIntervalForResource = 8
+        self.session = URLSession(configuration: configuration)
+
+        self.decoder = JSONDecoder()
+        self.encoder = JSONEncoder()
+
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let value = try container.decode(String.self)
+            let formatters: [ISO8601DateFormatter] = {
+                let fractional = ISO8601DateFormatter()
+                fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                let standard = ISO8601DateFormatter()
+                standard.formatOptions = [.withInternetDateTime]
+                return [fractional, standard]
+            }()
+
+            for formatter in formatters {
+                if let date = formatter.date(from: value) {
+                    return date
+                }
+            }
+
+            if let interval = TimeInterval(value) {
+                return Date(timeIntervalSince1970: interval)
+            }
+
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unrecognized date format: \(value)")
+        }
+
+        encoder.outputFormatting = [.prettyPrinted]
+    }
+
+    func request<T: Decodable>(url: URL,
+                               method: HTTPMethod = .get,
+                               headers: [String: String] = [:],
+                               body: Encodable? = nil,
+                               fallbackToEmptyBody: Bool = false,
+                               decode type: T.Type = T.self) async throws -> T {
+        let initialBodyData: Data?
+        if let body {
+            initialBodyData = try encoder.encode(AnyEncodable(body))
+        } else {
+            initialBodyData = nil
+        }
+
+        do {
+            return try await send(url: url,
+                                  method: method,
+                                  headers: headers,
+                                  bodyData: initialBodyData,
+                                  decode: T.self)
+        } catch let error as APIError {
+            if fallbackToEmptyBody,
+               case let .requestFailed(code) = error,
+               (code == 400 || code == 415) {
+                return try await send(url: url,
+                                      method: method,
+                                      headers: headers,
+                                      bodyData: nil,
+                                      decode: T.self)
+            }
+            throw error
+        }
+    }
+
+    private func send<T: Decodable>(url: URL,
+                                    method: HTTPMethod,
+                                    headers: [String: String],
+                                    bodyData: Data?,
+                                    decode type: T.Type) async throws -> T {
+        var request = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+        request.httpBody = bodyData
+
+        var combinedHeaders = headers
+        if bodyData != nil {
+            combinedHeaders["Content-Type"] = combinedHeaders["Content-Type"] ?? "application/json"
+        }
+        combinedHeaders["Accept"] = combinedHeaders["Accept"] ?? "application/json"
+
+        request.allHTTPHeaderFields = combinedHeaders
+
+        do {
+            let (data, response) = try await session.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw APIError.invalidResponse
+            }
+
+            guard 200..<300 ~= httpResponse.statusCode else {
+                throw APIError.requestFailed(httpResponse.statusCode)
+            }
+
+            if T.self == EmptyResponse.self {
+                return EmptyResponse() as! T
+            }
+
+            if data.isEmpty, let empty = EmptyResponse() as? T {
+                return empty
+            }
+
+            do {
+                return try decoder.decode(T.self, from: data)
+            } catch {
+                throw APIError.decodingFailed
+            }
+        } catch let error as APIError {
+            throw error
+        } catch {
+            let nsError = error as NSError
+            if nsError.code == NSURLErrorTimedOut || nsError.code == NSURLErrorCannotFindHost || nsError.code == NSURLErrorCannotConnectToHost {
+                throw APIError.unreachable
+            }
+            throw APIError.invalidResponse
+        }
+    }
+}
+
+private struct AnyEncodable: Encodable {
+    private let encodeClosure: (Encoder) throws -> Void
+
+    init(_ encodable: Encodable) {
+        self.encodeClosure = { encoder in
+            try encodable.encode(to: encoder)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try encodeClosure(encoder)
+    }
+}

--- a/SprinklerMobile/Networking/HTTPMethod.swift
+++ b/SprinklerMobile/Networking/HTTPMethod.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case delete = "DELETE"
+}

--- a/SprinklerMobile/Resources/Info.plist
+++ b/SprinklerMobile/Resources/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoadsInLocalNetworks</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/SprinklerMobile/SprinklerMobileApp.swift
+++ b/SprinklerMobile/SprinklerMobileApp.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+@main
+struct SprinklerMobileApp: App {
+    @StateObject private var settingsStore: SettingsStore
+    @StateObject private var appState: AppState
+
+    init() {
+        let settingsStore = SettingsStore()
+        _settingsStore = StateObject(wrappedValue: settingsStore)
+        _appState = StateObject(wrappedValue: AppState(settings: settingsStore))
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(settingsStore)
+                .environmentObject(appState)
+        }
+    }
+}
+
+private struct RootView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        TabView {
+            DashboardView()
+                .tabItem {
+                    Label("Dashboard", systemImage: "speedometer")
+                }
+            SchedulesView()
+                .tabItem {
+                    Label("Schedules", systemImage: "calendar")
+                }
+            SettingsView()
+                .tabItem {
+                    Label("Settings", systemImage: "gear")
+                }
+        }
+        .task {
+            await appState.refresh()
+        }
+    }
+}

--- a/SprinklerMobile/State/AppState.swift
+++ b/SprinklerMobile/State/AppState.swift
@@ -1,0 +1,306 @@
+import Foundation
+import Combine
+
+@MainActor
+final class AppState: ObservableObject {
+    enum ConnectionStatus: Equatable {
+        case idle
+        case connecting
+        case connected(Date)
+        case unreachable(String)
+
+        var bannerText: String {
+            switch self {
+            case .idle: return "Set Target IP"
+            case .connecting: return "Connecting…"
+            case .connected: return "Connected"
+            case .unreachable: return "Unreachable"
+            }
+        }
+
+        var isReachable: Bool {
+            if case .connected = self { return true }
+            return false
+        }
+    }
+
+    @Published private(set) var pins: [PinDTO] = []
+    @Published private(set) var schedules: [ScheduleDTO] = []
+    @Published private(set) var scheduleGroups: [ScheduleGroupDTO] = []
+    @Published private(set) var rain: RainDTO?
+    @Published var connectionStatus: ConnectionStatus = .idle
+    @Published var isRefreshing: Bool = false
+    @Published var toast: ToastState?
+
+    let settings: SettingsStore
+    private let client: APIClient
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(settings: SettingsStore, client: APIClient = APIClient()) {
+        self.settings = settings
+        self.client = client
+
+        if let base = settings.resolvedBaseURL {
+            Task { await client.updateBaseURL(base) }
+            if let last = settings.lastSuccessfulConnection {
+                connectionStatus = .connected(last)
+            } else {
+                connectionStatus = .idle
+            }
+        }
+
+        settings.$resolvedBaseURL
+            .removeDuplicates { $0 == $1 }
+            .sink { [weak self] url in
+                guard let self else { return }
+                Task { await self.client.updateBaseURL(url) }
+            }
+            .store(in: &cancellables)
+    }
+
+    func refresh() async {
+        guard settings.resolvedBaseURL != nil else { return }
+        isRefreshing = true
+        connectionStatus = .connecting
+        do {
+            let status = try await client.fetchStatus()
+            apply(status: status)
+            connectionStatus = .connected(Date())
+            settings.recordConnectionSuccess(version: status.version)
+        } catch let error as APIError {
+            connectionStatus = .unreachable(error.localizedDescription)
+            settings.recordConnectionFailure(error)
+            showToast(message: error.localizedDescription, style: .error)
+        } catch {
+            let apiError = APIError.invalidResponse
+            connectionStatus = .unreachable(apiError.localizedDescription)
+            settings.recordConnectionFailure(apiError)
+            showToast(message: apiError.localizedDescription, style: .error)
+        }
+        isRefreshing = false
+    }
+
+    func saveAndTestTarget() async {
+        settings.isTestingConnection = true
+        defer { settings.isTestingConnection = false }
+        do {
+            let url = try settings.resolveCurrentAddress()
+            await client.updateBaseURL(url)
+            await refresh()
+        } catch let error as APIError {
+            settings.setValidationError(error)
+            settings.recordConnectionFailure(error)
+            connectionStatus = .unreachable(error.localizedDescription)
+        } catch {
+            let apiError = APIError.invalidURL
+            settings.setValidationError(apiError)
+            settings.recordConnectionFailure(apiError)
+            connectionStatus = .unreachable(apiError.localizedDescription)
+        }
+    }
+
+    func togglePin(_ pin: PinDTO, to desiredState: Bool) {
+        guard let index = pins.firstIndex(where: { $0.id == pin.id }) else { return }
+        let previousState = pins[index].isActive
+        pins[index].isActive = desiredState
+
+        Task {
+            do {
+                try await client.setPin(pin.pin, on: desiredState)
+            } catch {
+                await MainActor.run {
+                    if let revertIndex = pins.firstIndex(where: { $0.id == pin.id }) {
+                        pins[revertIndex].isActive = previousState
+                    }
+                    showToast(message: "Failed to update pin", style: .error)
+                }
+            }
+        }
+    }
+
+    func renamePin(_ pin: PinDTO, newName: String) {
+        Task {
+            do {
+                try await client.renamePin(pin.pin, name: newName)
+                await MainActor.run {
+                    if let index = pins.firstIndex(where: { $0.id == pin.id }) {
+                        pins[index].name = newName
+                    }
+                    showToast(message: "Pin renamed", style: .success)
+                }
+            } catch {
+                await MainActor.run {
+                    showToast(message: "Rename failed", style: .error)
+                }
+            }
+        }
+    }
+
+    func setRain(active: Bool, durationHours: Int?) {
+        Task {
+            do {
+                try await client.setRain(isActive: active, durationHours: durationHours)
+                await refresh()
+                await MainActor.run {
+                    showToast(message: "Rain delay updated", style: .success)
+                }
+            } catch {
+                await MainActor.run {
+                    showToast(message: "Failed to update rain delay", style: .error)
+                }
+            }
+        }
+    }
+
+    func upsertSchedule(_ draft: ScheduleDraft) {
+        Task {
+            do {
+                if schedules.contains(where: { $0.id == draft.id }) {
+                    try await client.updateSchedule(id: draft.id, schedule: draft.payload)
+                } else {
+                    try await client.createSchedule(draft.payload)
+                }
+                await refresh()
+                await MainActor.run {
+                    showToast(message: "Schedule saved", style: .success)
+                }
+            } catch {
+                await MainActor.run {
+                    showToast(message: "Failed to save schedule", style: .error)
+                }
+            }
+        }
+    }
+
+    func deleteSchedule(_ schedule: ScheduleDTO) {
+        Task {
+            do {
+                try await client.deleteSchedule(id: schedule.id)
+                await refresh()
+                await MainActor.run {
+                    showToast(message: "Schedule deleted", style: .success)
+                }
+            } catch {
+                await MainActor.run {
+                    showToast(message: "Unable to delete schedule", style: .error)
+                }
+            }
+        }
+    }
+
+    func reorderSchedules(from offsets: IndexSet, to destination: Int) {
+        var reordered = schedules
+        reordered.move(fromOffsets: offsets, toOffset: destination)
+        schedules = reordered
+        Task {
+            do {
+                let order = reordered.map { $0.id }
+                try await client.reorderSchedules(order)
+            } catch {
+                await MainActor.run {
+                    showToast(message: "Failed to reorder schedules", style: .error)
+                }
+            }
+        }
+    }
+
+    func reorderPins(from offsets: IndexSet, to destination: Int) {
+        var reordered = pins
+        reordered.move(fromOffsets: offsets, toOffset: destination)
+        pins = reordered
+        Task {
+            do {
+                let order = reordered.map { $0.pin }
+                try await client.reorderPins(order)
+            } catch {
+                await MainActor.run {
+                    showToast(message: "Failed to reorder pins", style: .error)
+                }
+            }
+        }
+    }
+
+    func loadScheduleGroups() async {
+        do {
+            let groups = try await client.fetchScheduleGroups()
+            scheduleGroups = groups
+        } catch {
+            showToast(message: "Unable to load groups", style: .error)
+        }
+    }
+
+    func createScheduleGroup(name: String) {
+        Task {
+            do {
+                try await client.createScheduleGroup(name: name)
+                await loadScheduleGroups()
+                await MainActor.run {
+                    showToast(message: "Group created", style: .success)
+                }
+            } catch {
+                await MainActor.run {
+                    showToast(message: "Failed to create group", style: .error)
+                }
+            }
+        }
+    }
+
+    func selectScheduleGroup(id: String) {
+        Task {
+            do {
+                try await client.selectScheduleGroup(id: id)
+                await refresh()
+            } catch {
+                await MainActor.run {
+                    showToast(message: "Failed to select group", style: .error)
+                }
+            }
+        }
+    }
+
+    func addAllToGroup(id: String) {
+        Task {
+            do {
+                try await client.addAllToGroup(id: id)
+                await refresh()
+            } catch {
+                await MainActor.run {
+                    showToast(message: "Failed to add all", style: .error)
+                }
+            }
+        }
+    }
+
+    func deleteScheduleGroup(id: String) {
+        Task {
+            do {
+                try await client.deleteScheduleGroup(id: id)
+                await loadScheduleGroups()
+                await MainActor.run {
+                    showToast(message: "Group deleted", style: .success)
+                }
+            } catch {
+                await MainActor.run {
+                    showToast(message: "Failed to delete group", style: .error)
+                }
+            }
+        }
+    }
+
+    private func apply(status: StatusDTO) {
+        pins = status.pins ?? []
+        schedules = status.schedules ?? []
+        scheduleGroups = status.scheduleGroups ?? []
+        rain = status.rain
+    }
+
+    private func showToast(message: String, style: ToastState.Style) {
+        toast = ToastState(message: message, style: style)
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2.5))
+            if toast?.message == message {
+                toast = nil
+            }
+        }
+    }
+}

--- a/SprinklerMobile/State/ScheduleDraft.swift
+++ b/SprinklerMobile/State/ScheduleDraft.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct ScheduleDraft: Identifiable, Equatable {
+    var id: String
+    var name: String
+    var durationMinutes: Int
+    var startTime: String
+    var days: [String]
+    var isEnabled: Bool
+
+    init(id: String = UUID().uuidString,
+         name: String = "",
+         durationMinutes: Int = 10,
+         startTime: String = "06:00",
+         days: [String] = [],
+         isEnabled: Bool = true) {
+        self.id = id
+        self.name = name
+        self.durationMinutes = durationMinutes
+        self.startTime = startTime
+        self.days = days
+        self.isEnabled = isEnabled
+    }
+
+    init(schedule: ScheduleDTO) {
+        self.id = schedule.id
+        self.name = schedule.name ?? ""
+        self.durationMinutes = schedule.durationMinutes ?? 10
+        self.startTime = schedule.startTime ?? "06:00"
+        self.days = schedule.days ?? []
+        self.isEnabled = schedule.isEnabled ?? true
+    }
+
+    var payload: ScheduleWritePayload {
+        ScheduleWritePayload(name: name.isEmpty ? nil : name,
+                             durationMinutes: durationMinutes,
+                             startTime: startTime,
+                             days: days.isEmpty ? nil : days,
+                             isEnabled: isEnabled)
+    }
+}

--- a/SprinklerMobile/State/SettingsStore.swift
+++ b/SprinklerMobile/State/SettingsStore.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+@MainActor
+final class SettingsStore: ObservableObject {
+    @Published var targetAddress: String
+    @Published var validationError: String?
+    @Published private(set) var resolvedBaseURL: URL?
+    @Published var isTestingConnection: Bool = false
+    @Published var lastSuccessfulConnection: Date?
+    @Published var lastFailure: APIError?
+    @Published var serverVersion: String?
+
+    private let defaults: UserDefaults
+    private let targetKey = "sprinkler.target_address"
+    private let lastSuccessKey = "sprinkler.last_success"
+    private let versionKey = "sprinkler.server_version"
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.defaults = userDefaults
+        let savedAddress = userDefaults.string(forKey: targetKey) ?? ""
+        self.targetAddress = savedAddress
+        if let url = try? Validators.normalizeBaseAddress(savedAddress) {
+            self.resolvedBaseURL = url
+        }
+        self.lastSuccessfulConnection = userDefaults.object(forKey: lastSuccessKey) as? Date
+        self.serverVersion = userDefaults.string(forKey: versionKey)
+    }
+
+    func resolveCurrentAddress() throws -> URL {
+        let url = try Validators.normalizeBaseAddress(targetAddress)
+        validationError = nil
+        resolvedBaseURL = url
+        defaults.set(targetAddress, forKey: targetKey)
+        return url
+    }
+
+    func setValidationError(_ error: APIError) {
+        if case let .validationFailed(message) = error {
+            validationError = message
+        } else {
+            validationError = error.localizedDescription
+        }
+    }
+
+    func recordConnectionSuccess(version: String?) {
+        lastSuccessfulConnection = Date()
+        lastFailure = nil
+        defaults.set(lastSuccessfulConnection, forKey: lastSuccessKey)
+        if let version {
+            serverVersion = version
+            defaults.set(version, forKey: versionKey)
+        }
+    }
+
+    func recordConnectionFailure(_ error: APIError) {
+        lastFailure = error
+    }
+}

--- a/SprinklerMobile/Utils/Toast.swift
+++ b/SprinklerMobile/Utils/Toast.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct ToastState: Identifiable, Equatable {
+    enum Style {
+        case success
+        case error
+        case info
+
+        var background: Color {
+            switch self {
+            case .success: return Color.green.opacity(0.85)
+            case .error: return Color.red.opacity(0.85)
+            case .info: return Color.blue.opacity(0.85)
+            }
+        }
+    }
+
+    let id = UUID()
+    let message: String
+    let style: Style
+}
+
+struct ToastView: View {
+    let state: ToastState
+
+    var body: some View {
+        Text(state.message)
+            .font(.footnote)
+            .foregroundStyle(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(.thinMaterial.opacity(0.3))
+            .background(state.style.background)
+            .clipShape(Capsule())
+            .shadow(radius: 3)
+            .padding(.bottom, 24)
+    }
+}
+
+struct ToastModifier: ViewModifier {
+    @Binding var toast: ToastState?
+
+    func body(content: Content) -> some View {
+        ZStack(alignment: .bottom) {
+            content
+            if let toast {
+                ToastView(state: toast)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .animation(.easeInOut(duration: 0.2), value: toast)
+            }
+        }
+    }
+}
+
+extension View {
+    func toast(state: Binding<ToastState?>) -> some View {
+        modifier(ToastModifier(toast: state))
+    }
+}

--- a/SprinklerMobile/Utils/Validators.swift
+++ b/SprinklerMobile/Utils/Validators.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+enum Validators {
+    static func normalizeBaseAddress(_ rawValue: String) throws -> URL {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw APIError.validationFailed("Please enter the sprinkler controller address.")
+        }
+
+        guard var components = URLComponents(string: trimmed) else {
+            throw APIError.validationFailed("The address could not be parsed.")
+        }
+
+        guard let scheme = components.scheme?.lowercased(), ["http", "https"].contains(scheme) else {
+            throw APIError.validationFailed("The address must start with http:// or https://.")
+        }
+
+        guard components.host != nil else {
+            throw APIError.validationFailed("Please include the host or IP address.")
+        }
+
+        if components.path.isEmpty {
+            components.path = ""
+        }
+
+        guard let url = components.url else {
+            throw APIError.validationFailed("The address is not valid.")
+        }
+
+        return url
+    }
+}

--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct DashboardView: View {
+    @EnvironmentObject private var appState: AppState
+
+    private var toastBinding: Binding<ToastState?> {
+        Binding(get: { appState.toast }, set: { appState.toast = $0 })
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    connectionBanner
+                }
+                PinsListView(pins: appState.pins,
+                             onToggle: { pin, newValue in appState.togglePin(pin, to: newValue) },
+                             onReorder: appState.reorderPins)
+                Section("Rain Delay") {
+                    RainCardView(rain: appState.rain) { isActive, hours in
+                        appState.setRain(active: isActive, durationHours: hours)
+                    }
+                    .listRowInsets(EdgeInsets())
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Dashboard")
+            .toolbar { EditButton() }
+            .refreshable {
+                await appState.refresh()
+            }
+        }
+        .toast(state: toastBinding)
+    }
+
+    private var connectionBanner: some View {
+        HStack {
+            Image(systemName: appState.connectionStatus.isReachable ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(appState.connectionStatus.isReachable ? .green : .orange)
+            VStack(alignment: .leading) {
+                Text(appState.connectionStatus.bannerText)
+                    .font(.headline)
+                if let last = appState.settings.lastSuccessfulConnection {
+                    Text("Last Connected: \(last.formatted(date: .abbreviated, time: .shortened))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if let version = appState.settings.serverVersion {
+                    Text("Server Version: \(version)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                if case let .unreachable(message) = appState.connectionStatus {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+            Spacer()
+        }
+        .padding(.vertical, 8)
+    }
+}

--- a/SprinklerMobile/Views/PinRowView.swift
+++ b/SprinklerMobile/Views/PinRowView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct PinRowView: View {
+    let pin: PinDTO
+    let onToggle: (PinDTO, Bool) -> Void
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text(pin.name ?? "Pin \(pin.pin)")
+                    .font(.headline)
+                Text("GPIO \(pin.pin)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Toggle("", isOn: Binding(
+                get: { pin.isActive ?? false },
+                set: { newValue in onToggle(pin, newValue) }
+            ))
+            .labelsHidden()
+        }
+        .contentShape(Rectangle())
+        .padding(.vertical, 4)
+    }
+}

--- a/SprinklerMobile/Views/PinsListView.swift
+++ b/SprinklerMobile/Views/PinsListView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct PinsListView: View {
+    let pins: [PinDTO]
+    let onToggle: (PinDTO, Bool) -> Void
+    let onReorder: (IndexSet, Int) -> Void
+
+    var body: some View {
+        Section("Zones") {
+            if pins.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "square.stack.3d.down.forward")
+                        .font(.largeTitle)
+                        .foregroundStyle(.secondary)
+                    Text("No Pins Available")
+                        .font(.headline)
+                    Text("Pull to refresh once the controller is reachable.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 24)
+            } else {
+                ForEach(pins) { pin in
+                    PinRowView(pin: pin, onToggle: onToggle)
+                }
+                .onMove(perform: onReorder)
+            }
+        }
+    }
+}

--- a/SprinklerMobile/Views/RainCardView.swift
+++ b/SprinklerMobile/Views/RainCardView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct RainCardView: View {
+    let rain: RainDTO?
+    let onSubmit: (Bool, Int?) -> Void
+
+    @State private var isActive: Bool = false
+    @State private var durationHours: Int = 24
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle(isOn: $isActive) {
+                Text("Rain Delay")
+                    .font(.headline)
+            }
+            .toggleStyle(.switch)
+
+            Stepper(value: $durationHours, in: 1...72, step: 1) {
+                Text("Duration: \(durationHours)h")
+                    .font(.subheadline)
+            }
+            .disabled(!isActive)
+
+            if let endsAt = rain?.endsAt {
+                Text("Ends: \(endsAt.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button {
+                let duration = isActive ? durationHours : nil
+                onSubmit(isActive, duration)
+            } label: {
+                Text("Apply")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color(.secondarySystemBackground)))
+        .onChange(of: rain, perform: sync(with:))
+        .onAppear {
+            sync(with: rain)
+        }
+    }
+
+    private func sync(with rain: RainDTO?) {
+        isActive = rain?.isActive ?? false
+        if let hours = rain?.durationHours, hours > 0 {
+            durationHours = hours
+        }
+    }
+}

--- a/SprinklerMobile/Views/ScheduleEditorView.swift
+++ b/SprinklerMobile/Views/ScheduleEditorView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct ScheduleEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var draft: ScheduleDraft
+    let onSave: (ScheduleDraft) -> Void
+
+    private let dayOptions = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+    init(draft: ScheduleDraft, onSave: @escaping (ScheduleDraft) -> Void) {
+        _draft = State(initialValue: draft)
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Details") {
+                    TextField("Name", text: $draft.name)
+                    Stepper(value: $draft.durationMinutes, in: 1...180, step: 1) {
+                        Text("Duration: \(draft.durationMinutes) min")
+                    }
+                    TextField("Start (HH:mm)", text: $draft.startTime)
+                        .keyboardType(.numbersAndPunctuation)
+                    Toggle("Enabled", isOn: $draft.isEnabled)
+                }
+
+                Section("Days") {
+                    ForEach(dayOptions, id: \.self) { day in
+                        MultipleSelectionRow(title: day, isSelected: draft.days.contains(day)) {
+                            toggle(day: day)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Schedule")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        onSave(draft)
+                        dismiss()
+                    }
+                    .disabled(draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+    }
+
+    private func toggle(day: String) {
+        if draft.days.contains(day) {
+            draft.days.removeAll { $0 == day }
+        } else {
+            draft.days.append(day)
+        }
+    }
+}
+
+private struct MultipleSelectionRow: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                Spacer()
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.accent)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/SprinklerMobile/Views/ScheduleRowView.swift
+++ b/SprinklerMobile/Views/ScheduleRowView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct ScheduleRowView: View {
+    let schedule: ScheduleDTO
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(schedule.name ?? "Schedule")
+                .font(.headline)
+            HStack(spacing: 12) {
+                if let duration = schedule.durationMinutes {
+                    Label("\(duration) min", systemImage: "clock")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if let start = schedule.startTime {
+                    Label(start, systemImage: "alarm")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if let days = schedule.days, !days.isEmpty {
+                    Label(days.joined(separator: ", "), systemImage: "calendar")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(.vertical, 6)
+    }
+}

--- a/SprinklerMobile/Views/SchedulesView.swift
+++ b/SprinklerMobile/Views/SchedulesView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+struct SchedulesView: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var editingDraft: ScheduleDraft?
+    @State private var isPresentingEditor = false
+    @State private var isAddingGroup = false
+    @State private var newGroupName: String = ""
+
+    private var toastBinding: Binding<ToastState?> {
+        Binding(get: { appState.toast }, set: { appState.toast = $0 })
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Schedules") {
+                    if appState.schedules.isEmpty {
+                        VStack(spacing: 8) {
+                            Image(systemName: "calendar.badge.exclamationmark")
+                                .font(.largeTitle)
+                                .foregroundStyle(.secondary)
+                            Text("No schedules yet")
+                                .font(.headline)
+                            Text("Tap the plus button to add a watering plan.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 24)
+                    } else {
+                        ForEach(appState.schedules) { schedule in
+                            Button {
+                                editingDraft = ScheduleDraft(schedule: schedule)
+                                isPresentingEditor = true
+                            } label: {
+                                ScheduleRowView(schedule: schedule)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        .onDelete { indexSet in
+                            for index in indexSet {
+                                let schedule = appState.schedules[index]
+                                appState.deleteSchedule(schedule)
+                            }
+                        }
+                        .onMove(perform: appState.reorderSchedules)
+                    }
+                }
+
+                if !appState.scheduleGroups.isEmpty || isAddingGroup {
+                    Section("Groups") {
+                        ForEach(appState.scheduleGroups) { group in
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(group.name ?? "Group")
+                                    .font(.headline)
+                                HStack {
+                                    Button("Select") {
+                                        appState.selectScheduleGroup(id: group.id)
+                                    }
+                                    Button("Add All") {
+                                        appState.addAllToGroup(id: group.id)
+                                    }
+                                    Button(role: .destructive) {
+                                        appState.deleteScheduleGroup(id: group.id)
+                                    } label: {
+                                        Label("Delete", systemImage: "trash")
+                                    }
+                                }
+                                .buttonStyle(.borderless)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+
+                if isAddingGroup {
+                    Section("New Group") {
+                        TextField("Group name", text: $newGroupName)
+                        Button("Create") {
+                            let trimmed = newGroupName.trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !trimmed.isEmpty else { return }
+                            appState.createScheduleGroup(name: trimmed)
+                            newGroupName = ""
+                            withAnimation { isAddingGroup = false }
+                        }
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Schedules")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    EditButton()
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        editingDraft = ScheduleDraft()
+                        isPresentingEditor = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+                ToolbarItemGroup(placement: .bottomBar) {
+                    Button(isAddingGroup ? "Cancel" : "New Group") {
+                        withAnimation {
+                            isAddingGroup.toggle()
+                        }
+                        if !isAddingGroup {
+                            newGroupName = ""
+                        }
+                    }
+                }
+            }
+            .sheet(isPresented: $isPresentingEditor, onDismiss: { editingDraft = nil }) {
+                if let draft = editingDraft {
+                    ScheduleEditorView(draft: draft) { updated in
+                        appState.upsertSchedule(updated)
+                    }
+                }
+            }
+            .task {
+                await appState.loadScheduleGroups()
+            }
+        }
+        .toast(state: toastBinding)
+    }
+}

--- a/SprinklerMobile/Views/SettingsView.swift
+++ b/SprinklerMobile/Views/SettingsView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject private var settings: SettingsStore
+    @EnvironmentObject private var appState: AppState
+
+    private var toastBinding: Binding<ToastState?> {
+        Binding(get: { appState.toast }, set: { appState.toast = $0 })
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Target IP") {
+                    TextField("http://192.168.1.50:5000", text: $settings.targetAddress)
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.URL)
+                        .disableAutocorrection(true)
+                    if let error = settings.validationError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                    Button {
+                        Task { await appState.saveAndTestTarget() }
+                    } label: {
+                        if settings.isTestingConnection {
+                            ProgressView()
+                        } else {
+                            Text("Save & Test")
+                        }
+                    }
+                    .disabled(settings.targetAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || settings.isTestingConnection)
+                }
+
+                Section("Connection") {
+                    if let last = settings.lastSuccessfulConnection {
+                        LabeledContent("Last Success") {
+                            Text(last.formatted(date: .abbreviated, time: .shortened))
+                        }
+                    }
+                    if let version = settings.serverVersion {
+                        LabeledContent("Server Version") {
+                            Text(version)
+                        }
+                    }
+                    if let failure = settings.lastFailure {
+                        LabeledContent("Last Error") {
+                            Text(failure.localizedDescription)
+                                .foregroundStyle(.red)
+                        }
+                    }
+                }
+
+                Section("About") {
+                    Text("All commands are issued directly to the Raspberry Pi via its existing HTTP API. The server is never modified by the app.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("Settings")
+        }
+        .toast(state: toastBinding)
+    }
+}


### PR DESCRIPTION
## Summary
- add a SwiftUI app shell with tab navigation that wires SettingsStore and AppState into the environment for the sprinkler client
- implement networking, state management, and Codable models to communicate with the Raspberry Pi HTTP endpoints while handling validation, retries, and toast feedback
- build Dashboard, Schedules, and Settings views to control pins, rain delays, schedules, and target IP configuration, and update the README with integration instructions

## Testing
- not run (Swift-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cafa6c37dc833190aef2671261b58b