### PR TITLE
Add networking hardening with SSL pinning and secure storage

### DIFF
--- a/SprinklerMobile/Networking/SSLPinningDelegate.swift
+++ b/SprinklerMobile/Networking/SSLPinningDelegate.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Security
+
+final class SSLPinningDelegate: NSObject, URLSessionDelegate {
+    private let pinnedCertificates: [Data]
+
+    override init() {
+        if let urls = Bundle.main.urls(forResourcesWithExtension: "cer", subdirectory: nil) {
+            self.pinnedCertificates = urls.compactMap { try? Data(contentsOf: $0) }
+        } else {
+            self.pinnedCertificates = []
+        }
+        super.init()
+    }
+
+    func urlSession(_ session: URLSession,
+                    didReceive challenge: URLAuthenticationChallenge,
+                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let serverTrust = challenge.protectionSpace.serverTrust else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        guard !pinnedCertificates.isEmpty else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        let policies = NSMutableArray()
+        policies.add(SecPolicyCreateSSL(true, challenge.protectionSpace.host as CFString))
+        SecTrustSetPolicies(serverTrust, policies)
+
+        var trustError: CFError?
+        guard SecTrustEvaluateWithError(serverTrust, &trustError) else {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+            return
+        }
+
+        let serverCertificatesCount = SecTrustGetCertificateCount(serverTrust)
+        for index in 0..<serverCertificatesCount {
+            guard let certificate = SecTrustGetCertificateAtIndex(serverTrust, index) else { continue }
+            let serverCertificateData = SecCertificateCopyData(certificate) as Data
+            if pinnedCertificates.contains(serverCertificateData) {
+                let credential = URLCredential(trust: serverTrust)
+                completionHandler(.useCredential, credential)
+                return
+            }
+        }
+
+        completionHandler(.cancelAuthenticationChallenge, nil)
+    }
+}

--- a/SprinklerMobile/Utils/KeychainStorage.swift
+++ b/SprinklerMobile/Utils/KeychainStorage.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Security
+
+protocol KeychainStoring {
+    func string(forKey key: String) -> String?
+    func set(_ value: String, forKey key: String) throws
+    func deleteValue(forKey key: String)
+}
+
+enum KeychainError: Error {
+    case unexpectedStatus(OSStatus)
+}
+
+struct KeychainStorage: KeychainStoring {
+    private let service: String
+
+    init(service: String = Bundle.main.bundleIdentifier ?? "com.sprinkler.app") {
+        self.service = service
+    }
+
+    func string(forKey key: String) -> String? {
+        var query = baseQuery(forKey: key)
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecReturnData as String] = kCFBooleanTrue
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess else { return nil }
+        guard let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    func set(_ value: String, forKey key: String) throws {
+        guard let data = value.data(using: .utf8) else { return }
+
+        var query = baseQuery(forKey: key)
+        query[kSecValueData as String] = data
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        switch status {
+        case errSecSuccess:
+            return
+        case errSecDuplicateItem:
+            let updateStatus = SecItemUpdate(baseQuery(forKey: key) as CFDictionary,
+                                             [kSecValueData as String: data] as CFDictionary)
+            guard updateStatus == errSecSuccess else {
+                throw KeychainError.unexpectedStatus(updateStatus)
+            }
+        default:
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func deleteValue(forKey key: String) {
+        let query = baseQuery(forKey: key)
+        SecItemDelete(query as CFDictionary)
+    }
+
+    private func baseQuery(forKey key: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- add an SSL pinning delegate and hook it into the HTTP client
- introduce caching, retry handling, and cached fallbacks for GET requests
- store the controller address securely in the keychain with migration from UserDefaults

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb00ae2a248331bb7aecae85d4baec