### PR TITLE
Add loading skeletons and optimize state refresh

### DIFF
--- a/SprinklerMobile/Utils/SkeletonView.swift
+++ b/SprinklerMobile/Utils/SkeletonView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+struct ShimmerViewModifier: ViewModifier {
+    @State private var phase: CGFloat = -1
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                GeometryReader { geometry in
+                    let gradient = LinearGradient(colors: [
+                        Color(.systemGray5),
+                        Color(.systemGray3),
+                        Color(.systemGray5)
+                    ], startPoint: .top, endPoint: .bottom)
+
+                    Rectangle()
+                        .fill(gradient)
+                        .rotationEffect(.degrees(20))
+                        .offset(x: phase * geometry.size.width * 2)
+                        .frame(width: geometry.size.width * 1.5)
+                }
+                .mask(content)
+            }
+            .onAppear {
+                phase = -1
+                withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) {
+                    phase = 1
+                }
+            }
+    }
+}
+
+extension View {
+    func shimmering() -> some View {
+        modifier(ShimmerViewModifier())
+    }
+}
+
+struct SkeletonLine: View {
+    var height: CGFloat = 12
+    var cornerRadius: CGFloat = 6
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: cornerRadius)
+            .fill(Color(.systemGray5))
+            .frame(height: height)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .shimmering()
+    }
+}
+
+struct ToggleSkeleton: View {
+    var body: some View {
+        Capsule()
+            .fill(Color(.systemGray5))
+            .frame(width: 50, height: 30)
+            .shimmering()
+    }
+}
+
+struct PinRowSkeleton: View {
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 8) {
+                SkeletonLine(height: 16)
+                SkeletonLine(height: 12)
+                    .frame(maxWidth: 120)
+            }
+            Spacer()
+            ToggleSkeleton()
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct ScheduleRowSkeleton: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SkeletonLine(height: 16)
+            HStack(spacing: 12) {
+                SkeletonLine(height: 12)
+                    .frame(maxWidth: 60)
+                SkeletonLine(height: 12)
+                    .frame(maxWidth: 80)
+                SkeletonLine(height: 12)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+}
+
+struct RainCardSkeleton: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            SkeletonLine(height: 16)
+            SkeletonLine(height: 14)
+                .frame(maxWidth: 100)
+            SkeletonLine(height: 14)
+                .frame(maxWidth: 140)
+            SkeletonLine(height: 44, cornerRadius: 12)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color(.secondarySystemBackground)))
+    }
+}
+
+struct ScheduleGroupSkeleton: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SkeletonLine(height: 16)
+                .frame(maxWidth: 120)
+            SkeletonLine(height: 12)
+                .frame(maxWidth: 180)
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -14,10 +14,12 @@ struct DashboardView: View {
                     connectionBanner
                 }
                 PinsListView(pins: appState.pins,
+                             isLoading: appState.isRefreshing && appState.pins.isEmpty,
                              onToggle: { pin, newValue in appState.togglePin(pin, to: newValue) },
                              onReorder: appState.reorderPins)
                 Section("Rain Delay") {
-                    RainCardView(rain: appState.rain) { isActive, hours in
+                    RainCardView(rain: appState.rain,
+                                 isLoading: appState.isRefreshing && appState.rain == nil) { isActive, hours in
                         appState.setRain(active: isActive, durationHours: hours)
                     }
                     .listRowInsets(EdgeInsets())

--- a/SprinklerMobile/Views/PinsListView.swift
+++ b/SprinklerMobile/Views/PinsListView.swift
@@ -2,12 +2,24 @@ import SwiftUI
 
 struct PinsListView: View {
     let pins: [PinDTO]
+    let isLoading: Bool
     let onToggle: (PinDTO, Bool) -> Void
     let onReorder: (IndexSet, Int) -> Void
 
+    init(pins: [PinDTO], isLoading: Bool = false, onToggle: @escaping (PinDTO, Bool) -> Void, onReorder: @escaping (IndexSet, Int) -> Void) {
+        self.pins = pins
+        self.isLoading = isLoading
+        self.onToggle = onToggle
+        self.onReorder = onReorder
+    }
+
     var body: some View {
         Section("Zones") {
-            if pins.isEmpty {
+            if isLoading {
+                ForEach(0..<4, id: \.self) { _ in
+                    PinRowSkeleton()
+                }
+            } else if pins.isEmpty {
                 VStack(spacing: 8) {
                     Image(systemName: "square.stack.3d.down.forward")
                         .font(.largeTitle)

--- a/SprinklerMobile/Views/RainCardView.swift
+++ b/SprinklerMobile/Views/RainCardView.swift
@@ -2,49 +2,68 @@ import SwiftUI
 
 struct RainCardView: View {
     let rain: RainDTO?
+    let isLoading: Bool
     let onSubmit: (Bool, Int?) -> Void
+
+    init(rain: RainDTO?, isLoading: Bool = false, onSubmit: @escaping (Bool, Int?) -> Void) {
+        self.rain = rain
+        self.isLoading = isLoading
+        self.onSubmit = onSubmit
+    }
 
     @State private var isActive: Bool = false
     @State private var durationHours: Int = 24
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Toggle(isOn: $isActive) {
-                Text("Rain Delay")
-                    .font(.headline)
-            }
-            .toggleStyle(.switch)
+        Group {
+            if isLoading {
+                RainCardSkeleton()
+            } else {
+                VStack(alignment: .leading, spacing: 12) {
+                    Toggle(isOn: $isActive) {
+                        Text("Rain Delay")
+                            .font(.headline)
+                    }
+                    .toggleStyle(.switch)
 
-            Stepper(value: $durationHours, in: 1...72, step: 1) {
-                Text("Duration: \(durationHours)h")
-                    .font(.subheadline)
-            }
-            .disabled(!isActive)
+                    Stepper(value: $durationHours, in: 1...72, step: 1) {
+                        Text("Duration: \(durationHours)h")
+                            .font(.subheadline)
+                    }
+                    .disabled(!isActive)
 
-            if let endsAt = rain?.endsAt {
-                Text("Ends: \(endsAt.formatted(date: .abbreviated, time: .shortened))")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
+                    if let endsAt = rain?.endsAt {
+                        Text("Ends: \(endsAt.formatted(date: .abbreviated, time: .shortened))")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
 
-            Button {
-                let duration = isActive ? durationHours : nil
-                onSubmit(isActive, duration)
-            } label: {
-                Text("Apply")
-                    .frame(maxWidth: .infinity)
+                    Button {
+                        let duration = isActive ? durationHours : nil
+                        onSubmit(isActive, duration)
+                    } label: {
+                        Text("Apply")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+                .background(RoundedRectangle(cornerRadius: 12).fill(Color(.secondarySystemBackground)))
             }
-            .buttonStyle(.borderedProminent)
         }
-        .padding()
-        .background(RoundedRectangle(cornerRadius: 12).fill(Color(.secondarySystemBackground)))
         .onChange(of: rain, perform: sync(with:))
+        .onChange(of: isLoading) { newValue in
+            if !newValue {
+                sync(with: rain)
+            }
+        }
         .onAppear {
             sync(with: rain)
         }
     }
 
     private func sync(with rain: RainDTO?) {
+        guard !isLoading else { return }
         isActive = rain?.isActive ?? false
         if let hours = rain?.durationHours, hours > 0 {
             durationHours = hours


### PR DESCRIPTION
## Summary
- add a reusable shimmering skeleton toolkit and apply it across dashboard and schedules loading states
- surface loading placeholders for schedule groups while adopting a lazy button stack for large button rows
- guard refresh assignments to avoid redundant `@Published` updates during status polling

## Testing
- not run (requires Xcode environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb021999e883318971538f7239fee1