### PR TITLE
Add CFBundleExecutable to Info.plist

### DIFF
--- a/SprinklerMobile/Resources/Info.plist
+++ b/SprinklerMobile/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
     <key>NSAppTransportSecurity</key>
     <dict>
         <key>NSAllowsArbitraryLoadsInLocalNetworks</key>


### PR DESCRIPTION
## Summary
- add the CFBundleExecutable key to the app Info.plist so Xcode can determine the executable when installing on device

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb08abaf948331a49d7f03da71d8af