### PR TITLE
Fix checkmark accent color usage

### DIFF
--- a/SprinklerMobile/Views/ScheduleEditorView.swift
+++ b/SprinklerMobile/Views/ScheduleEditorView.swift
@@ -70,7 +70,7 @@ private struct MultipleSelectionRow: View {
                 Spacer()
                 if isSelected {
                     Image(systemName: "checkmark")
-                        .foregroundStyle(.accent)
+                        .foregroundStyle(.tint)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- replace the deprecated `.accent` shape style with `.tint` for the checkmark indicator in the schedule editor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb0d7077988331924f0d7ad5526123