### PR TITLE
Add local network usage description

### DIFF
--- a/SprinklerMobile/Resources/Info.plist
+++ b/SprinklerMobile/Resources/Info.plist
@@ -9,5 +9,7 @@
         <key>NSAllowsArbitraryLoadsInLocalNetworks</key>
         <true/>
     </dict>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>This app uses your local network to connect to the sprinkler controller.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- add a local network usage description string so iOS prompts for access to the sprinkler controller

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cb0e8b086883319b5e38402dffca6e