### PR TITLE
Add pin renaming controls

### DIFF
--- a/SprinklerMobile/Data/PinDTO.swift
+++ b/SprinklerMobile/Data/PinDTO.swift
@@ -8,6 +8,11 @@ struct PinDTO: Codable, Identifiable, Hashable {
     var isActive: Bool?
     var isEnabled: Bool?
 
+    var displayName: String {
+        let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "GPIO \(pin)" : trimmed
+    }
+
     enum CodingKeys: String, CodingKey {
         case pin
         case name

--- a/SprinklerMobile/Views/PinRowView.swift
+++ b/SprinklerMobile/Views/PinRowView.swift
@@ -6,13 +6,8 @@ struct PinRowView: View {
 
     var body: some View {
         HStack {
-            VStack(alignment: .leading) {
-                Text(pin.name ?? "Pin \(pin.pin)")
-                    .font(.headline)
-                Text("GPIO \(pin.pin)")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-            }
+            Text(pin.displayName)
+                .font(.headline)
             Spacer()
             Toggle("", isOn: Binding(
                 get: { pin.isActive ?? false },

--- a/SprinklerMobile/Views/SettingsView.swift
+++ b/SprinklerMobile/Views/SettingsView.swift
@@ -32,6 +32,20 @@ struct SettingsView: View {
                     .disabled(store.targetAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || store.isTestingConnection)
                 }
 
+                Section("Pins") {
+                    if store.pins.isEmpty {
+                        Text("No Pins Available")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(Array(store.pins.enumerated()), id: \.element.id) { index, pin in
+                            PinSettingsRow(pin: pin,
+                                           position: index + 1) { updatedPin, newName in
+                                store.renamePin(updatedPin, newName: newName)
+                            }
+                        }
+                    }
+                }
+
                 Section("Connection") {
                     if let last = store.lastSuccessfulConnection {
                         LabeledContent("Last Success") {
@@ -60,5 +74,60 @@ struct SettingsView: View {
             .navigationTitle("Settings")
         }
         .toast(state: toastBinding)
+    }
+}
+
+private struct PinSettingsRow: View {
+    let pin: PinDTO
+    let position: Int
+    let onRename: (PinDTO, String) -> Void
+
+    @State private var name: String
+    @FocusState private var isFocused: Bool
+
+    init(pin: PinDTO, position: Int, onRename: @escaping (PinDTO, String) -> Void) {
+        self.pin = pin
+        self.position = position
+        self.onRename = onRename
+        _name = State(initialValue: pin.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("GPIO \(pin.pin)")
+                    .font(.subheadline)
+                Spacer()
+                Text("Pin #\(position)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            TextField("Name", text: $name, prompt: Text(pin.displayName))
+                .textInputAutocapitalization(.words)
+                .disableAutocorrection(true)
+                .submitLabel(.done)
+                .focused($isFocused)
+                .onSubmit(commitRename)
+        }
+        .onChange(of: pin) { updatedPin in
+            let trimmed = updatedPin.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if trimmed != name {
+                name = trimmed
+            }
+        }
+        .onChange(of: isFocused) { focused in
+            if !focused {
+                commitRename()
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func commitRename() {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let current = pin.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard trimmed != current else { return }
+        onRename(pin, trimmed)
     }
 }


### PR DESCRIPTION
## Summary
- add a computed display name for pins so that dashboard rows show user-provided labels with a GPIO fallback
- simplify the dashboard pin row to display only the configured name
- list all GPIO pins in Settings with their pin numbers and inline text fields to rename them

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cb1fb66e8c83319df087fefb90bdc8