### PR TITLE
Add pin visibility toggles and update rename flow

### DIFF
--- a/SprinklerMobile/Data/APIClient.swift
+++ b/SprinklerMobile/Data/APIClient.swift
@@ -52,10 +52,29 @@ actor APIClient {
                                          decode: EmptyResponse.self)
     }
 
-    func renamePin(_ pin: Int, name: String) async throws {
-        let url = try makeURL(path: "/api/pin/\(pin)/name")
-        struct RenamePayload: Encodable { let name: String }
-        let payload = RenamePayload(name: name)
+    func updatePin(_ pin: Int, name: String?, isEnabled: Bool) async throws {
+        let url = try makeURL(path: "/api/pin/\(pin)")
+        struct PinUpdatePayload: Encodable {
+            let name: String?
+            let isEnabled: Bool
+
+            enum CodingKeys: String, CodingKey {
+                case name
+                case isEnabled = "is_enabled"
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                if let name {
+                    try container.encode(name, forKey: .name)
+                } else {
+                    try container.encodeNil(forKey: .name)
+                }
+                try container.encode(isEnabled, forKey: .isEnabled)
+            }
+        }
+
+        let payload = PinUpdatePayload(name: name, isEnabled: isEnabled)
         _ = try await httpClient.request(url: url,
                                          method: .post,
                                          body: payload,

--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -13,7 +13,8 @@ struct DashboardView: View {
                 Section {
                     connectionBanner
                 }
-                PinsListView(pins: store.pins,
+                PinsListView(pins: store.activePins,
+                             totalPinCount: store.pins.count,
                              isLoading: store.isRefreshing && store.pins.isEmpty,
                              onToggle: { pin, newValue in store.togglePin(pin, to: newValue) },
                              onReorder: store.reorderPins)

--- a/SprinklerMobile/Views/PinsListView.swift
+++ b/SprinklerMobile/Views/PinsListView.swift
@@ -2,12 +2,18 @@ import SwiftUI
 
 struct PinsListView: View {
     let pins: [PinDTO]
+    let totalPinCount: Int
     let isLoading: Bool
     let onToggle: (PinDTO, Bool) -> Void
     let onReorder: (IndexSet, Int) -> Void
 
-    init(pins: [PinDTO], isLoading: Bool = false, onToggle: @escaping (PinDTO, Bool) -> Void, onReorder: @escaping (IndexSet, Int) -> Void) {
+    init(pins: [PinDTO],
+         totalPinCount: Int,
+         isLoading: Bool = false,
+         onToggle: @escaping (PinDTO, Bool) -> Void,
+         onReorder: @escaping (IndexSet, Int) -> Void) {
         self.pins = pins
+        self.totalPinCount = totalPinCount
         self.isLoading = isLoading
         self.onToggle = onToggle
         self.onReorder = onReorder
@@ -20,18 +26,33 @@ struct PinsListView: View {
                     PinRowSkeleton()
                 }
             } else if pins.isEmpty {
-                VStack(spacing: 8) {
-                    Image(systemName: "square.stack.3d.down.forward")
-                        .font(.largeTitle)
-                        .foregroundStyle(.secondary)
-                    Text("No Pins Available")
-                        .font(.headline)
-                    Text("Pull to refresh once the controller is reachable.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                if totalPinCount == 0 {
+                    VStack(spacing: 8) {
+                        Image(systemName: "square.stack.3d.down.forward")
+                            .font(.largeTitle)
+                            .foregroundStyle(.secondary)
+                        Text("No Pins Available")
+                            .font(.headline)
+                        Text("Pull to refresh once the controller is reachable.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 24)
+                } else {
+                    VStack(spacing: 8) {
+                        Image(systemName: "eye.slash")
+                            .font(.largeTitle)
+                            .foregroundStyle(.secondary)
+                        Text("No Active Pins")
+                            .font(.headline)
+                        Text("Enable pins from Settings to manage them here.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 24)
                 }
-                .frame(maxWidth: .infinity, alignment: .center)
-                .padding(.vertical, 24)
             } else {
                 ForEach(pins) { pin in
                     PinRowView(pin: pin, onToggle: onToggle)


### PR DESCRIPTION
## Summary
- add an API client helper for updating pin metadata (name and visibility)
- update the sprinkler store to normalize names, handle visibility toggles, and only show active pins on the dashboard
- surface pin activation toggles in settings and refresh dashboard list messaging when no pins are active

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cb21e64e688331a7d213ec823486b3