### PR TITLE
Add automated rain delay controls and expanded GPIO visibility

### DIFF
--- a/SprinklerMobile/Data/APIClient.swift
+++ b/SprinklerMobile/Data/APIClient.swift
@@ -23,6 +23,30 @@ actor APIClient {
         return try await httpClient.request(url: url)
     }
 
+    func updateRainSettings(zipCode: String, thresholdPercent: Int, isEnabled: Bool) async throws {
+        let url = try makeURL(path: "/api/rain/settings")
+        struct RainSettingsPayload: Encodable {
+            let zipCode: String
+            let thresholdPercent: Int
+            let isEnabled: Bool
+
+            enum CodingKeys: String, CodingKey {
+                case zipCode = "zip_code"
+                case thresholdPercent = "threshold_percent"
+                case isEnabled = "is_enabled"
+            }
+        }
+
+        let payload = RainSettingsPayload(zipCode: zipCode,
+                                          thresholdPercent: thresholdPercent,
+                                          isEnabled: isEnabled)
+        _ = try await httpClient.request(url: url,
+                                         method: .post,
+                                         body: payload,
+                                         fallbackToEmptyBody: false,
+                                         decode: EmptyResponse.self)
+    }
+
     func setRain(isActive: Bool, durationHours: Int?) async throws {
         let url = try makeURL(path: "/api/rain")
         struct RainPayload: Encodable {

--- a/SprinklerMobile/Data/RainDTO.swift
+++ b/SprinklerMobile/Data/RainDTO.swift
@@ -4,10 +4,18 @@ struct RainDTO: Codable, Equatable {
     let isActive: Bool?
     let endsAt: Date?
     let durationHours: Int?
+    let chancePercent: Int?
+    let thresholdPercent: Int?
+    let zipCode: String?
+    let automationEnabled: Bool?
 
     enum CodingKeys: String, CodingKey {
         case isActive = "is_active"
         case endsAt = "ends_at"
         case durationHours = "duration_hours"
+        case chancePercent = "chance_percent"
+        case thresholdPercent = "threshold_percent"
+        case zipCode = "zip_code"
+        case automationEnabled = "automation_enabled"
     }
 }

--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -13,16 +13,17 @@ struct DashboardView: View {
                 Section {
                     connectionBanner
                 }
-                PinsListView(pins: store.activePins,
+                PinsListView(pins: store.pins,
                              totalPinCount: store.pins.count,
                              isLoading: store.isRefreshing && store.pins.isEmpty,
                              onToggle: { pin, newValue in store.togglePin(pin, to: newValue) },
                              onReorder: store.reorderPins)
                 Section("Rain Delay") {
                     RainCardView(rain: store.rain,
-                                 isLoading: store.isRefreshing && store.rain == nil) { isActive, hours in
-                        store.setRain(active: isActive, durationHours: hours)
-                    }
+                                 isLoading: store.isRefreshing && store.rain == nil,
+                                 isAutomationEnabled: store.rainAutomationEnabled,
+                                 isUpdatingAutomation: store.isUpdatingRainAutomation,
+                                 onToggleAutomation: { store.setRainAutomationEnabled($0) })
                     .listRowInsets(EdgeInsets())
                 }
             }

--- a/SprinklerMobile/Views/PinRowView.swift
+++ b/SprinklerMobile/Views/PinRowView.swift
@@ -4,18 +4,36 @@ struct PinRowView: View {
     let pin: PinDTO
     let onToggle: (PinDTO, Bool) -> Void
 
+    private var canToggle: Bool {
+        pin.isEnabled ?? true
+    }
+
     var body: some View {
-        HStack {
-            Text(pin.displayName)
-                .font(.headline)
-            Spacer()
-            Toggle("", isOn: Binding(
-                get: { pin.isActive ?? false },
-                set: { newValue in onToggle(pin, newValue) }
-            ))
-            .labelsHidden()
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(pin.displayName)
+                    .font(.headline)
+                Spacer()
+                Toggle("", isOn: Binding(
+                    get: { pin.isActive ?? false },
+                    set: { newValue in
+                        if canToggle {
+                            onToggle(pin, newValue)
+                        }
+                    }
+                ))
+                .labelsHidden()
+                .disabled(!canToggle)
+            }
+
+            if !canToggle {
+                Text("Enable in Settings to control this zone.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .contentShape(Rectangle())
         .padding(.vertical, 4)
+        .opacity(canToggle ? 1 : 0.45)
     }
 }

--- a/SprinklerMobile/Views/PinsListView.swift
+++ b/SprinklerMobile/Views/PinsListView.swift
@@ -7,6 +7,14 @@ struct PinsListView: View {
     let onToggle: (PinDTO, Bool) -> Void
     let onReorder: (IndexSet, Int) -> Void
 
+    private var enabledPins: [PinDTO] {
+        pins.filter { $0.isEnabled ?? true }
+    }
+
+    private var hiddenPins: [PinDTO] {
+        pins.filter { !($0.isEnabled ?? true) }
+    }
+
     init(pins: [PinDTO],
          totalPinCount: Int,
          isLoading: Bool = false,
@@ -54,10 +62,40 @@ struct PinsListView: View {
                     .padding(.vertical, 24)
                 }
             } else {
-                ForEach(pins) { pin in
-                    PinRowView(pin: pin, onToggle: onToggle)
+                if enabledPins.isEmpty {
+                    VStack(spacing: 8) {
+                        Image(systemName: "bolt.horizontal.circle")
+                            .font(.largeTitle)
+                            .foregroundStyle(.secondary)
+                        Text("No Enabled Pins")
+                            .font(.headline)
+                        Text("Enable pins from Settings to control them here.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 24)
+                } else {
+                    ForEach(enabledPins) { pin in
+                        PinRowView(pin: pin, onToggle: onToggle)
+                    }
+                    .onMove(perform: onReorder)
                 }
-                .onMove(perform: onReorder)
+
+                if !hiddenPins.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Hidden Pins")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.top, enabledPins.isEmpty ? 0 : 12)
+
+                        ForEach(hiddenPins) { pin in
+                            PinRowView(pin: pin, onToggle: onToggle)
+                                .allowsHitTesting(false)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
             }
         }
     }

--- a/SprinklerMobile/Views/SettingsView.swift
+++ b/SprinklerMobile/Views/SettingsView.swift
@@ -50,6 +50,44 @@ struct SettingsView: View {
                     }
                 }
 
+                Section("Rain Delay Automation") {
+                    TextField("ZIP Code", text: $store.rainSettingsZip)
+                        .keyboardType(.numberPad)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
+
+                    TextField("Threshold (%)", text: $store.rainSettingsThreshold)
+                        .keyboardType(.numberPad)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
+
+                    Toggle("Enable Automation", isOn: $store.rainSettingsIsEnabled)
+
+                    if let chance = store.rain?.chancePercent {
+                        LabeledContent("Current Chance of Rain") {
+                            Text("\(chance)%")
+                                .font(.subheadline)
+                        }
+                    } else {
+                        Text("Chance of rain will populate after saving a ZIP code.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Button {
+                        Task { await store.saveRainSettings() }
+                    } label: {
+                        if store.isSavingRainSettings {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                        } else {
+                            Text("Save Rain Settings")
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .disabled(store.isSavingRainSettings)
+                }
+
                 Section("Connection") {
                     if let last = store.lastSuccessfulConnection {
                         LabeledContent("Last Success") {


### PR DESCRIPTION
## Summary
- extend the rain models and API client to support fetching rain chance, zip code, automation status, and configuration updates
- teach the store and dashboard to display every GPIO, manage rain automation state, and surface richer rain delay status
- add rain delay automation settings for zip, threshold, and enablement to the settings screen with validation

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cb3dddbe1c8331ad9f3c29970520a4