### PR TITLE
Normalize and validate sprinkler base URL

### DIFF
--- a/SprinklerMobile/Utils/Validators.swift
+++ b/SprinklerMobile/Utils/Validators.swift
@@ -1,41 +1,138 @@
 import Foundation
 
 enum Validators {
-    static func normalizeBaseAddress(_ rawValue: String) throws -> URL {
+    private static let allowedSchemes: Set<String> = ["http", "https"]
+
+    /// Normalizes a base address entered by the user into a canonical URL that the rest of the
+    /// networking stack can safely reuse.
+    /// - Parameters:
+    ///   - rawValue: The raw, user supplied string.
+    ///   - restrictToLocalNetwork: When `true`, IPv4 entries must be within RFC1918 ranges and
+    ///   IPv6 entries must be loopback or unique/local scope. Hostnames without a TLD are treated
+    ///   as LAN entries. Pass `false` to allow any well formed host.
+    /// - Returns: A normalized URL ready to persist and reuse.
+    static func normalizeBaseAddress(_ rawValue: String,
+                                     restrictToLocalNetwork: Bool = true) throws -> URL {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             throw APIError.validationFailed("Please enter the sprinkler controller address.")
         }
 
-        let components = URLComponents(string: trimmed)
-        let normalizedComponents: URLComponents
-
-        if let components, let scheme = components.scheme, !scheme.isEmpty {
-            normalizedComponents = components
-        } else {
-            guard let fallbackComponents = URLComponents(string: "http://\(trimmed)") else {
-                throw APIError.validationFailed("The address could not be parsed.")
-            }
-            normalizedComponents = fallbackComponents
+        let preparedValue = trimmed.contains("://") ? trimmed : "http://\(trimmed)"
+        guard var components = URLComponents(string: preparedValue) else {
+            throw APIError.validationFailed("The address could not be parsed.")
         }
 
-        guard let scheme = normalizedComponents.scheme?.lowercased(), ["http", "https"].contains(scheme) else {
+        if components.scheme?.isEmpty ?? true {
+            components.scheme = "http"
+        }
+
+        components.scheme = components.scheme?.lowercased()
+        guard let scheme = components.scheme, allowedSchemes.contains(scheme) else {
             throw APIError.validationFailed("The address must start with http:// or https://.")
         }
 
-        guard normalizedComponents.host != nil else {
+        guard components.user == nil, components.password == nil else {
+            throw APIError.validationFailed("Usernames and passwords are not supported in the address.")
+        }
+
+        if let host = components.host?.trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty {
+            components.host = host.lowercased()
+        }
+
+        guard let host = components.host, !host.isEmpty else {
             throw APIError.validationFailed("Please include the host or IP address.")
         }
 
-        var mutableComponents = normalizedComponents
-        if mutableComponents.path.isEmpty {
-            mutableComponents.path = ""
+        if restrictToLocalNetwork, !isHostAllowedOnLocalNetwork(host) {
+            throw APIError.validationFailed("Please enter a local network address (e.g. 10.x.x.x, 172.16-31.x.x, or 192.168.x.x).")
         }
 
-        guard let url = mutableComponents.url else {
+        if let port = components.port,
+           let defaultPort = defaultPort(forScheme: scheme),
+           port == defaultPort {
+            components.port = nil
+        }
+
+        if components.percentEncodedPath.isEmpty || components.percentEncodedPath == "/" {
+            components.percentEncodedPath = ""
+        }
+        components.query = nil
+        components.fragment = nil
+
+        guard let url = components.url else {
             throw APIError.validationFailed("The address is not valid.")
         }
 
         return url
+    }
+
+    private static func defaultPort(forScheme scheme: String) -> Int? {
+        switch scheme {
+        case "http":
+            return 80
+        case "https":
+            return 443
+        default:
+            return nil
+        }
+    }
+
+    private static func isHostAllowedOnLocalNetwork(_ host: String) -> Bool {
+        if host == "localhost" || host == "127.0.0.1" {
+            return true
+        }
+
+        if host.hasSuffix(".local") || host.hasSuffix(".lan") {
+            return true
+        }
+
+        if !host.contains(".") && !host.contains(":") {
+            return true
+        }
+
+        if let octets = ipv4Octets(for: host) {
+            return isRFC1918(octets)
+        }
+
+        if host.contains(":") {
+            return isLocalIPv6(host)
+        }
+
+        return false
+    }
+
+    private static func ipv4Octets(for host: String) -> [UInt8]? {
+        let parts = host.split(separator: ".")
+        guard parts.count == 4 else { return nil }
+
+        var octets: [UInt8] = []
+        octets.reserveCapacity(4)
+
+        for part in parts {
+            guard let value = UInt8(part) else { return nil }
+            octets.append(value)
+        }
+
+        return octets
+    }
+
+    private static func isRFC1918(_ octets: [UInt8]) -> Bool {
+        guard octets.count == 4 else { return false }
+        switch octets[0] {
+        case 10:
+            return true
+        case 172 where (16...31).contains(octets[1]):
+            return true
+        case 192 where octets[1] == 168:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isLocalIPv6(_ host: String) -> Bool {
+        let normalized = host.lowercased()
+        return normalized == "::1" || normalized.hasPrefix("fe80") || normalized.hasPrefix("fd") || normalized.hasPrefix("fc")
     }
 }

--- a/SprinklerMobile/Views/SettingsView.swift
+++ b/SprinklerMobile/Views/SettingsView.swift
@@ -15,10 +15,24 @@ struct SettingsView: View {
                         .textInputAutocapitalization(.never)
                         .keyboardType(.URL)
                         .disableAutocorrection(true)
+                        .textContentType(.URL)
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 4)
+                        .background {
+                            RoundedRectangle(cornerRadius: 8)
+                                .strokeBorder(store.validationError == nil ? Color.secondary.opacity(0.2) : .red,
+                                              lineWidth: store.validationError == nil ? 0.5 : 1.5)
+                        }
+                        .accessibilityHint("Enter the sprinkler controller base URL.")
                     if let error = store.validationError {
-                        Text(error)
-                            .font(.caption)
-                            .foregroundStyle(.red)
+                        Label {
+                            Text(error)
+                        } icon: {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .accessibilityLabel(Text("Validation error: \(error)"))
                     }
                     Button {
                         Task { await store.saveAndTestTarget() }


### PR DESCRIPTION
## Summary
- centralize base URL canonicalization with scheme defaults, port cleanup, and LAN host checks
- persist the normalized base URL in the store so all networking reuses the canonical value
- improve settings UI feedback for validation errors with clearer highlighting and messaging

## Testing
- Not run (iOS project without automated test target in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb49ed53fc833190c7ca6a663001c8