### PR TITLE
Initialize targetAddress default value

### DIFF
--- a/SprinklerMobile/Stores/SprinklerStore.swift
+++ b/SprinklerMobile/Stores/SprinklerStore.swift
@@ -53,7 +53,7 @@ final class SprinklerStore: ObservableObject {
     @Published private(set) var connectionDiagnostics: ConnectionDiagnostics?
 
     // Settings state
-    @Published var targetAddress: String
+    @Published var targetAddress: String = ""
     @Published var validationError: String?
     @Published private(set) var resolvedBaseURL: URL?
     @Published var isTestingConnection: Bool = false


### PR DESCRIPTION
## Summary
- set the sprinkler store's target address to an empty string by default to satisfy Swift initialization rules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb66b1bf40833198a3818ab8856312