### PR TITLE
Ensure default pin catalog is available without GPIOCatalog file

### DIFF
--- a/SprinklerMobile/Data/GPIOCatalog.swift
+++ b/SprinklerMobile/Data/GPIOCatalog.swift
@@ -1,33 +1,14 @@
 import Foundation
 
-/// Catalog of sprinkler zones that the mobile client can expose before it
-/// successfully downloads the definitive configuration from the controller.
-///
-/// The production controller is wired to eight relay outputs that drive the
-/// irrigation solenoids. Publishing just those sprinklers keeps the placeholder
-/// UI realistic for installers and prevents the app from surfacing pins that
-/// are either unsafe to toggle or connected to other peripherals on the Pi.
+/// Compatibility shim that preserves the previous `GPIOCatalog` API while the
+/// project transitions to the new static helpers defined on `PinDTO`.
 struct GPIOCatalog {
-    /// Default GPIO configuration that mirrors the eight production sprinkler
-    /// zones connected to the Raspberry Pi controller. The numbers are the
-    /// Broadcom (BCM) pin identifiers used by the backend and pigpio.
-    private static let defaultPins: [PinDTO] = [
-        PinDTO(pin: 4, name: "Zone 1", isActive: false, isEnabled: true),
-        PinDTO(pin: 17, name: "Zone 2", isActive: false, isEnabled: true),
-        PinDTO(pin: 27, name: "Zone 3", isActive: false, isEnabled: true),
-        PinDTO(pin: 22, name: "Zone 4", isActive: false, isEnabled: true),
-        PinDTO(pin: 5, name: "Zone 5", isActive: false, isEnabled: true),
-        PinDTO(pin: 6, name: "Zone 6", isActive: false, isEnabled: true),
-        PinDTO(pin: 13, name: "Zone 7", isActive: false, isEnabled: true),
-        PinDTO(pin: 19, name: "Zone 8", isActive: false, isEnabled: true)
-    ]
-
     /// GPIO pin numbers that are safe for the UI to expose.
-    static let safeOutputPins: [Int] = defaultPins.map(\.pin)
+    static let safeOutputPins: [Int] = PinDTO.sprinklerSafeOutputPins
 
     /// Creates placeholder pins for the UI when no controller data is
     /// available.
     static func makeDefaultPins() -> [PinDTO] {
-        defaultPins
+        PinDTO.makeDefaultSprinklerPins()
     }
 }

--- a/SprinklerMobile/Data/PinDTO.swift
+++ b/SprinklerMobile/Data/PinDTO.swift
@@ -20,3 +20,31 @@ struct PinDTO: Codable, Identifiable, Hashable {
         case isEnabled = "is_enabled"
     }
 }
+
+extension PinDTO {
+    /// Static catalog that mirrors the physical relay wiring on the Raspberry Pi
+    /// controller. These pins drive the irrigation solenoids in production and
+    /// provide a realistic placeholder list before the mobile client downloads
+    /// live configuration data from the backend.
+    static let defaultSprinklerCatalog: [PinDTO] = [
+        PinDTO(pin: 4, name: "Zone 1", isActive: false, isEnabled: true),
+        PinDTO(pin: 17, name: "Zone 2", isActive: false, isEnabled: true),
+        PinDTO(pin: 27, name: "Zone 3", isActive: false, isEnabled: true),
+        PinDTO(pin: 22, name: "Zone 4", isActive: false, isEnabled: true),
+        PinDTO(pin: 5, name: "Zone 5", isActive: false, isEnabled: true),
+        PinDTO(pin: 6, name: "Zone 6", isActive: false, isEnabled: true),
+        PinDTO(pin: 13, name: "Zone 7", isActive: false, isEnabled: true),
+        PinDTO(pin: 19, name: "Zone 8", isActive: false, isEnabled: true)
+    ]
+
+    /// Convenience accessor that exposes just the safe-to-drive GPIO pin numbers
+    /// for scenarios where only the numeric identifier is needed.
+    static let sprinklerSafeOutputPins: [Int] = defaultSprinklerCatalog.map(\.pin)
+
+    /// Returns a placeholder list of sprinkler pins that mirrors the production
+    /// relay wiring. The UI uses this while waiting for the Pi controller to
+    /// respond so installers can still preview the layout.
+    static func makeDefaultSprinklerPins() -> [PinDTO] {
+        defaultSprinklerCatalog
+    }
+}

--- a/SprinklerMobile/Stores/SprinklerStore.swift
+++ b/SprinklerMobile/Stores/SprinklerStore.swift
@@ -32,7 +32,7 @@ final class SprinklerStore: ObservableObject {
     }
 
     // Remote resources
-    @Published private(set) var pins: [PinDTO] = GPIOCatalog.makeDefaultPins()
+    @Published private(set) var pins: [PinDTO] = PinDTO.makeDefaultSprinklerPins()
     var activePins: [PinDTO] {
         pins.filter { $0.isEnabled ?? true }
     }
@@ -575,7 +575,7 @@ final class SprinklerStore: ObservableObject {
     /// Blends controller supplied pin metadata with the static catalog so every
     /// safely drivable GPIO appears in the UI even if the backend omits it.
     private func mergePinsWithCatalog(_ remotePins: [PinDTO]) -> [PinDTO] {
-        let catalog = GPIOCatalog.safeOutputPins
+        let catalog = PinDTO.sprinklerSafeOutputPins
         let catalogSet = Set(catalog)
 
         var catalogOverrides: [Int: PinDTO] = [:]


### PR DESCRIPTION
## Summary
- add static helpers on `PinDTO` that publish the sprinkler pin catalog and safe output list so they are always compiled with the target
- update `SprinklerStore` to rely on the new helpers and leave a thin `GPIOCatalog` shim for backwards compatibility

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb84dd33f88331940f83c9646819f4