### PR TITLE
Fix rain automation payload and surface API errors

### DIFF
--- a/SprinklerMobile/Data/APIClient.swift
+++ b/SprinklerMobile/Data/APIClient.swift
@@ -30,18 +30,18 @@ actor APIClient {
         struct RainSettingsPayload: Encodable {
             let zipCode: String
             let thresholdPercent: Int
-            let isEnabled: Bool
+            let automationEnabled: Bool
 
             enum CodingKeys: String, CodingKey {
                 case zipCode = "zip_code"
                 case thresholdPercent = "threshold_percent"
-                case isEnabled = "is_enabled"
+                case automationEnabled = "automation_enabled"
             }
         }
 
         let payload = RainSettingsPayload(zipCode: zipCode,
                                           thresholdPercent: thresholdPercent,
-                                          isEnabled: isEnabled)
+                                          automationEnabled: isEnabled)
         let endpoint = Endpoint<EmptyResponse>(path: "/api/rain/settings",
                                                method: .post,
                                                body: AnyEncodable(payload))

--- a/SprinklerMobile/Stores/SprinklerStore.swift
+++ b/SprinklerMobile/Stores/SprinklerStore.swift
@@ -252,7 +252,8 @@ final class SprinklerStore: ObservableObject {
                     if let revertIndex = self.pins.firstIndex(where: { $0.id == pin.id }) {
                         self.pins[revertIndex] = previousPin
                     }
-                    self.showToast(message: "Rename failed", style: .error)
+                    self.showToast(message: self.toastMessage(for: error, defaultMessage: "Rename failed"),
+                                   style: .error)
                 }
             }
         }
@@ -327,7 +328,9 @@ final class SprinklerStore: ObservableObject {
                 await MainActor.run {
                     self.rainAutomationEnabled = previousValue
                     self.rainSettingsIsEnabled = previousValue
-                    self.showToast(message: "Failed to update automation", style: .error)
+                    self.showToast(message: self.toastMessage(for: error,
+                                                               defaultMessage: "Failed to update automation"),
+                                   style: .error)
                 }
             }
             await MainActor.run {
@@ -361,7 +364,8 @@ final class SprinklerStore: ObservableObject {
             await refresh()
             showToast(message: "Rain settings saved", style: .success)
         } catch {
-            showToast(message: "Failed to save rain settings", style: .error)
+            showToast(message: toastMessage(for: error, defaultMessage: "Failed to save rain settings"),
+                      style: .error)
         }
     }
 
@@ -665,6 +669,13 @@ final class SprinklerStore: ObservableObject {
             return nil
         }
         return threshold
+    }
+
+    private func toastMessage(for error: Error, defaultMessage: String) -> String {
+        if let apiError = error as? APIError {
+            return apiError.localizedDescription
+        }
+        return defaultMessage
     }
 
     /// Persists the latest in-memory status so future launches (and offline


### PR DESCRIPTION
## Summary
- send the rain automation update payload using the backend's `automation_enabled` key so updates persist
- bubble API error details into the toast helper for pin rename and rain automation actions to avoid generic failures
- reuse the new toast helper when saving automation settings so user feedback reflects real server errors

## Testing
- Not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68cb87b897f08331b36ca820e24f78b3