### PR TITLE
Fix rename pin endpoint path

### DIFF
--- a/SprinklerMobile/Data/APIClient.swift
+++ b/SprinklerMobile/Data/APIClient.swift
@@ -81,7 +81,7 @@ actor APIClient {
         }
 
         let payload = PinUpdatePayload(name: name, isEnabled: isEnabled)
-        let endpoint = Endpoint<EmptyResponse>(path: "/api/pin/\(pin)",
+        let endpoint = Endpoint<EmptyResponse>(path: "/api/pins/\(pin)",
                                                method: .post,
                                                body: AnyEncodable(payload))
         _ = try await perform(endpoint)


### PR DESCRIPTION
## Summary
- update the rename-pin API request to use the pluralized `/api/pins/<pin>` route so the backend no longer returns a 404

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb8c0b38a88331865ffb6a881a0fb3