### PR TITLE
Add ConnectivityStore, BonjourDiscoveryService, DiscoveryViewModel, and supporting files for Phase 1 & 2

### DIFF
--- a/SprinklerMobile/Services/BonjourDiscoveryService.swift
+++ b/SprinklerMobile/Services/BonjourDiscoveryService.swift
@@ -2,6 +2,7 @@ import Foundation
 #if canImport(Combine)
 import Combine
 #else
+/// Lightweight stand-ins for Combine types so the Linux build does not fail.
 public struct AnyPublisher<Output, Failure: Error> {
     public init() {}
 }
@@ -17,19 +18,19 @@ final class CurrentValueSubject<Output, Failure: Error> {
 }
 #endif
 
-/// Protocol describing the discovery interface used by the app.
+/// Abstracts Bonjour discovery so the view model can react to changes through Combine.
 protocol BonjourDiscoveryProviding: AnyObject {
-    /// Publisher emitting currently discovered devices.
+    /// Publisher emitting current list of discovered sprinkler controllers.
     var devicesPublisher: AnyPublisher<[DiscoveredDevice], Never> { get }
     /// Starts Bonjour discovery.
     func start()
-    /// Stops Bonjour discovery.
+    /// Stops the ongoing discovery session.
     func stop()
-    /// Refreshes the discovery session.
+    /// Requests a fresh discovery run.
     func refresh()
 }
 
-/// Stubbed discovery service that keeps the project building even without Bonjour integration.
+/// Stubbed implementation that keeps the project compiling while discovery is being built out.
 final class BonjourDiscoveryService: BonjourDiscoveryProviding {
     private let subject = CurrentValueSubject<[DiscoveredDevice], Never>([])
     var devicesPublisher: AnyPublisher<[DiscoveredDevice], Never> { subject.eraseToAnyPublisher() }

--- a/SprinklerMobile/Services/HealthChecker.swift
+++ b/SprinklerMobile/Services/HealthChecker.swift
@@ -5,10 +5,11 @@ import FoundationNetworking
 
 /// Abstraction used to verify sprinkler controller connectivity.
 protocol ConnectivityChecking {
+    /// Executes a connectivity check against the provided base URL.
     func check(baseURL: URL) async -> ConnectivityState
 }
 
-/// Performs connectivity checks against the sprinkler controller's status endpoint.
+/// Performs a simple `/api/status` health check to validate connectivity to the controller.
 struct HealthChecker: ConnectivityChecking {
     private let session: URLSession
 
@@ -16,7 +17,6 @@ struct HealthChecker: ConnectivityChecking {
         self.session = session
     }
 
-    /// Invokes `/api/status` on the provided base URL and returns the resulting connectivity state.
     func check(baseURL: URL) async -> ConnectivityState {
         var statusURL = baseURL
         statusURL.append(path: "/api/status")

--- a/SprinklerMobile/Stores/ConnectivityStore.swift
+++ b/SprinklerMobile/Stores/ConnectivityStore.swift
@@ -2,6 +2,7 @@ import Foundation
 #if canImport(SwiftUI)
 import SwiftUI
 #else
+/// Minimal stand-ins so the package compiles on platforms without SwiftUI (e.g., Linux CI).
 @propertyWrapper
 struct Published<Value> {
     var wrappedValue: Value
@@ -12,16 +13,16 @@ struct Published<Value> {
 protocol ObservableObject {}
 #endif
 
-/// Stores the connectivity settings and state for communicating with the sprinkler controller.
+/// Stores connectivity information and state for communicating with the sprinkler controller.
 @MainActor
 final class ConnectivityStore: ObservableObject {
-    /// Base URL string for the sprinkler controller API. Persists to user defaults on change.
+    /// Base URL string entered by the user. Persisted to user defaults whenever it changes.
     @Published var baseURLString: String {
         didSet { defaults.set(baseURLString, forKey: Self.udKey) }
     }
-    /// Current connectivity state for the controller.
+    /// Published connectivity state that informs the UI whether we can reach the controller.
     @Published var state: ConnectivityState = .offline(errorDescription: nil)
-    /// Whether a connectivity check is currently in progress.
+    /// Indicates when a connectivity check is currently running to avoid duplicate requests.
     @Published var isChecking: Bool = false
 
     private let checker: ConnectivityChecking
@@ -36,10 +37,10 @@ final class ConnectivityStore: ObservableObject {
         self.checker = checker
     }
 
-    /// Public entry point for refreshing connectivity state.
+    /// Convenience entry point for the UI to trigger a fresh connectivity check.
     func refresh() async { await testConnection() }
 
-    /// Tests connectivity to the configured base URL, updating the published state accordingly.
+    /// Calls the health checker against the normalized base URL and updates published state.
     func testConnection() async {
         let trimmed = baseURLString.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let url = ConnectivityStore.normalizedBaseURL(from: trimmed) else {
@@ -52,7 +53,7 @@ final class ConnectivityStore: ObservableObject {
         await MainActor.run { self.state = result }
     }
 
-    /// Normalizes a human-entered string into a usable base URL, defaulting to HTTP when missing.
+    /// Normalizes text entered by the user by prepending `http://` when missing.
     static func normalizedBaseURL(from s: String) -> URL? {
         var str = s
         if !str.lowercased().hasPrefix("http://") && !str.lowercased().hasPrefix("https://") {
@@ -62,7 +63,7 @@ final class ConnectivityStore: ObservableObject {
     }
 }
 
-/// Represents connectivity state for the sprinkler controller.
+/// Lightweight enum describing whether the sprinkler controller is reachable.
 enum ConnectivityState: Equatable {
     case connected
     case offline(errorDescription: String?)

--- a/SprinklerMobile/ViewModels/DiscoveryViewModel.swift
+++ b/SprinklerMobile/ViewModels/DiscoveryViewModel.swift
@@ -4,14 +4,14 @@ import Dispatch
 import Combine
 #endif
 
-/// Bridges Bonjour discovery events into SwiftUI-friendly published properties.
+/// Bridges the Bonjour discovery service to SwiftUI-friendly published properties.
 @MainActor
 final class DiscoveryViewModel: ObservableObject {
-    /// Discovered devices surfaced to the UI.
+    /// Devices currently discovered on the network.
     @Published var devices: [DiscoveredDevice] = []
-    /// Indicates whether discovery is currently active.
+    /// Whether discovery is currently active to help drive UI state.
     @Published var isBrowsing: Bool = false
-    /// Holds any user-facing error message from discovery.
+    /// Optional error message that can be surfaced to the user.
     @Published var errorMessage: String?
 
     private let service: BonjourDiscoveryProviding
@@ -29,13 +29,13 @@ final class DiscoveryViewModel: ObservableObject {
         #endif
     }
 
-    /// Starts Bonjour discovery and flips the state flag.
+    /// Starts discovery and flips the browsing flag.
     func start() {
         isBrowsing = true
         service.start()
     }
 
-    /// Requests a refresh from the service, typically re-browsing.
+    /// Forces a new discovery pass by calling refresh on the service.
     func refresh() {
         isBrowsing = true
         service.refresh()


### PR DESCRIPTION
## Summary
- add inline documentation to the new connectivity, discovery service, and discovery view model files
- keep SwiftUI/Combine fallbacks so the SwiftPM package builds on Linux while still matching the desired project structure
- document connectivity checking via the HealthChecker abstraction used by ConnectivityStore

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cc35ea9c90833199fe0b6eba05d382