### PR TITLE
Guard XCTest imports in package tests

### DIFF
--- a/Tests/SprinklerConnectivityTests/BonjourDiscoveryServiceTests.swift
+++ b/Tests/SprinklerConnectivityTests/BonjourDiscoveryServiceTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 @testable import SprinklerConnectivity
 
@@ -12,3 +13,4 @@ final class BonjourDiscoveryServiceTests: XCTestCase {
         XCTAssertEqual(device.baseURLString, "http://[fd00::1]:8000")
     }
 }
+#endif

--- a/Tests/SprinklerConnectivityTests/ConnectivityStoreTests.swift
+++ b/Tests/SprinklerConnectivityTests/ConnectivityStoreTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 @testable import SprinklerConnectivity
 
@@ -41,3 +42,4 @@ private actor MockHealthChecker: ConnectivityChecking {
         return result
     }
 }
+#endif

--- a/Tests/SprinklerConnectivityTests/HealthCheckerTests.swift
+++ b/Tests/SprinklerConnectivityTests/HealthCheckerTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -113,3 +114,4 @@ final class StubURLProtocol: URLProtocol {
         // No-op
     }
 }
+#endif


### PR DESCRIPTION
## Summary
- wrap the SprinklerConnectivity package test files in `#if canImport(XCTest)` guards so the sources compile cleanly even if Xcode accidentally includes them in app builds

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cc6dc72f288331b5e4e9d9440af732