### PR TITLE
Fix launch screen initial view controller

### DIFF
--- a/SprinklerMobile/Resources/LaunchScreen.storyboard
+++ b/SprinklerMobile/Resources/LaunchScreen.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17150" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17150" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17122"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>


### PR DESCRIPTION
## Summary
- set the launch storyboard's root view controller as the initial entry point to resolve Xcode warnings

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cc72ac1d108331a1fa033bd273ef47