### PR TITLE
Use vector app icon

### DIFF
--- a/SprinklerMobile/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SprinklerMobile/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.000",
+          "green": "0.478",
+          "blue": "1.000",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/SprinklerMobile/Resources/Assets.xcassets/AppIcon.appiconset/AppIcon.pdf
+++ b/SprinklerMobile/Resources/Assets.xcassets/AppIcon.appiconset/AppIcon.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 1024 1024] /Contents 4 0 R /Resources << /ProcSet [/PDF] >> >>
+endobj
+4 0 obj
+<< /Length 76 >>
+stream
+0 0 0 rg
+0 0 1024 1024 re
+f
+0.05098 0.43529 0.75686 rg
+128 128 768 768 re
+f
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000237 00000 n 
+trailer << /Size 5 /Root 1 0 R >>
+startxref
+362
+%%EOF

--- a/SprinklerMobile/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SprinklerMobile/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,24 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "filename": "AppIcon.pdf",
+      "platform": "ios",
+      "size": "1024x1024"
+    },
+    {
+      "idiom": "ios-marketing",
+      "filename": "AppIcon.pdf",
+      "size": "1024x1024",
+      "scale": "1x"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  },
+  "properties": {
+    "preserves-vector-representation": true,
+    "pre-rendered": true
+  }
+}

--- a/SprinklerMobile/Resources/Assets.xcassets/Contents.json
+++ b/SprinklerMobile/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}


### PR DESCRIPTION
## Summary
- replace the placeholder PNG icons with a single vector-based app icon asset
- update the asset catalog metadata to consume the shared PDF and preserve vector rendering

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cc743ea470833198cb81588ba14373