### PR TITLE
Fix health check handling for unrecognized controller status

### DIFF
--- a/SprinklerMobile/Services/HealthChecker.swift
+++ b/SprinklerMobile/Services/HealthChecker.swift
@@ -127,6 +127,6 @@ struct HealthChecker: ConnectivityChecking {
             }
         }
 
-        return true
+        return nil
     }
 }

--- a/Tests/SprinklerConnectivityTests/HealthCheckerTests.swift
+++ b/Tests/SprinklerConnectivityTests/HealthCheckerTests.swift
@@ -40,6 +40,19 @@ final class HealthCheckerTests: XCTestCase {
         }
     }
 
+    func testOfflineWhenServerReturnsUnrecognizedStatusField() async {
+        configureStub(statusCode: 200, data: Data("{\"status\":\"mystery\"}".utf8))
+        let checker = HealthChecker(session: makeSession(protocolClass: StubURLProtocol.self))
+
+        let result = await checker.check(baseURL: URL(string: "http://example.com")!)
+
+        if case let .offline(description) = result {
+            XCTAssertNotNil(description)
+        } else {
+            XCTFail("Expected offline state")
+        }
+    }
+
     func testOfflineWhenControllerReportsUnhealthyStatus() async {
         configureStub(statusCode: 200, data: Data("{\"ok\":false}".utf8))
         let checker = HealthChecker(session: makeSession(protocolClass: StubURLProtocol.self))


### PR DESCRIPTION
## Summary
- treat unrecognized controller status payloads as failures instead of silently succeeding
- add a regression test that ensures mysterious status strings surface as offline states

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cc8e3218a08331a43134cbace51d8d