### PR TITLE
Add iOS support to connectivity package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 let package = Package(
     name: "SprinklerConnectivity",
     platforms: [
+        .iOS(.v16),
         .macOS(.v13)
     ],
     products: [


### PR DESCRIPTION
## Summary
- allow the SprinklerConnectivity package to build for iOS by declaring iOS 16 support in the manifest

## Testing
- swift build
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cc94bd041883318da0237142e1f45c