### PR TITLE
Fix build issues in Sprink app

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,13 @@
 // swift-tools-version: 5.8
+#if canImport(PackageDescription)
 import PackageDescription
 
+/// Swift Package manifest that exposes the connectivity components of the
+/// Sprinkler mobile app as a standalone library so they can be reused by other
+/// targets (for example the Raspberry Pi test harness). Wrapping the manifest
+/// in a `canImport` check keeps Xcode from trying to compile the file when the
+/// iOS application target builds, which previously resulted in a
+/// `No such module 'PackageDescription'` compiler error.
 let package = Package(
     name: "SprinklerConnectivity",
     platforms: [
@@ -37,3 +44,4 @@ let package = Package(
         )
     ]
 )
+#endif

--- a/SprinklerMobile/Resources/LaunchScreen.storyboard
+++ b/SprinklerMobile/Resources/LaunchScreen.storyboard
@@ -10,7 +10,7 @@
         <!--View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController id="Y6W-OH-hqX" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LaunchScreenViewController" id="Y6W-OH-hqX" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
## Summary
- wrap the Swift package manifest in a `canImport(PackageDescription)` check so Xcode no longer tries to compile it with the iOS target
- add a storyboard identifier to the launch screen view controller to silence Interface Builder diagnostics

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ccb60488dc8331a19a84f2b786688f