### PR TITLE
Fix Package.swift import guard for iOS builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,14 @@
 // swift-tools-version: 5.8
-#if canImport(PackageDescription)
+#if canImport(PackageDescription) && !os(iOS)
 import PackageDescription
 
 /// Swift Package manifest that exposes the connectivity components of the
 /// Sprinkler mobile app as a standalone library so they can be reused by other
 /// targets (for example the Raspberry Pi test harness). Wrapping the manifest
-/// in a `canImport` check keeps Xcode from trying to compile the file when the
-/// iOS application target builds, which previously resulted in a
+/// in a conditional check keeps Xcode from trying to compile the file when the
+/// iOS application target builds. The additional `!os(iOS)` guard prevents the
+/// compiler from attempting to import the SwiftPM only `PackageDescription`
+/// module when archiving for device, which previously resulted in a
 /// `No such module 'PackageDescription'` compiler error.
 let package = Package(
     name: "SprinklerConnectivity",


### PR DESCRIPTION
## Summary
- add an explicit !os(iOS) condition around the SwiftPM manifest so Xcode skips Package.swift during device builds
- document why the additional guard is necessary to avoid the `No such module 'PackageDescription'` error while still exposing the connectivity library for SwiftPM consumers

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ccb9c2c60c8331945a9463629f922c