### PR TITLE
Adjust test imports for Sprink_ module

### DIFF
--- a/Tests/SprinklerConnectivityTests/BonjourDiscoveryServiceTests.swift
+++ b/Tests/SprinklerConnectivityTests/BonjourDiscoveryServiceTests.swift
@@ -1,6 +1,10 @@
 #if canImport(XCTest)
 import XCTest
+#if canImport(Sprink_)
+@testable import Sprink_
+#else
 @testable import SprinklerConnectivity
+#endif
 
 final class BonjourDiscoveryServiceTests: XCTestCase {
     func testBaseURLPrefersHost() {

--- a/Tests/SprinklerConnectivityTests/ConnectivityStoreTests.swift
+++ b/Tests/SprinklerConnectivityTests/ConnectivityStoreTests.swift
@@ -1,6 +1,10 @@
 #if canImport(XCTest)
 import XCTest
+#if canImport(Sprink_)
+@testable import Sprink_
+#else
 @testable import SprinklerConnectivity
+#endif
 
 final class ConnectivityStoreTests: XCTestCase {
     func testBaseURLPersistsToUserDefaults() async {

--- a/Tests/SprinklerConnectivityTests/HealthCheckerTests.swift
+++ b/Tests/SprinklerConnectivityTests/HealthCheckerTests.swift
@@ -3,7 +3,11 @@ import XCTest
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
+#if canImport(Sprink_)
+@testable import Sprink_
+#else
 @testable import SprinklerConnectivity
+#endif
 
 final class HealthCheckerTests: XCTestCase {
     func testConnectedWhenServerReturnsValidJSON() async throws {


### PR DESCRIPTION
## Summary
- conditionally import the Sprink_ module in all SprinklerConnectivity test targets while keeping compatibility with the SprinklerConnectivity package

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ccbecb7edc833186362e49e5a5871e