### PR TITLE
Enable native iPad layout

### DIFF
--- a/SprinklerMobile/Resources/Info.plist
+++ b/SprinklerMobile/Resources/Info.plist
@@ -29,5 +29,10 @@
     <key>NSAllowsArbitraryLoadsInLocalNetworks</key>
     <true/>
   </dict>
+  <key>UIDeviceFamily</key>
+  <array>
+    <integer>1</integer>
+    <integer>2</integer>
+  </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- add the UIDeviceFamily plist entry so the iOS target advertises native iPad support rather than running in iPhone compatibility mode

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ccdcb22f908331b8b3cbe0c1249605