### PR TITLE
Revamp dashboard and settings interface

### DIFF
--- a/SprinklerMobile/SprinklerMobileApp.swift
+++ b/SprinklerMobile/SprinklerMobileApp.swift
@@ -25,5 +25,6 @@ private struct RootView: View {
                     Label("Settings", systemImage: "gear")
                 }
         }
+        .tint(.green)
     }
 }

--- a/SprinklerMobile/Stores/ConnectivityStore.swift
+++ b/SprinklerMobile/Stores/ConnectivityStore.swift
@@ -24,6 +24,8 @@ final class ConnectivityStore: ObservableObject {
     @Published var state: ConnectivityState = .offline(errorDescription: nil)
     /// Indicates when a connectivity check is currently running to avoid duplicate requests.
     @Published var isChecking: Bool = false
+    /// Tracks when a connectivity check last completed so the UI can surface recency information.
+    @Published var lastCheckedDate: Date?
 
     private let checker: ConnectivityChecking
     private let defaults: UserDefaults
@@ -56,6 +58,7 @@ final class ConnectivityStore: ObservableObject {
         isChecking = true
         defer { isChecking = false }
         let result = await checker.check(baseURL: url)
+        lastCheckedDate = Date()
         self.state = result
     }
 

--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -1,28 +1,450 @@
 import SwiftUI
+#if os(iOS)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
+/// Shared relative date formatter so all components display consistent phrasing.
+private let dashboardRelativeFormatter: RelativeDateTimeFormatter = {
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .short
+    return formatter
+}()
+
+/// Landing view that presents a rich overview of the sprinkler controller's health
+/// and quick access to the most common actions.
 struct DashboardView: View {
     @EnvironmentObject private var store: ConnectivityStore
+    @State private var showCopiedToast = false
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         NavigationStack {
-            List {
-                Section("Connection") {
-                    ConnectivityBadgeView(state: store.state, isLoading: store.isChecking)
-                    if case let .offline(error?) = store.state {
-                        Text(error)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
+            ZStack {
+                // A subtle background gradient keeps the dashboard feeling lively without
+                // overpowering the content so the cards remain the primary focus.
+                LinearGradient(colors: [Color.appBackground, Color.appSecondaryBackground],
+                               startPoint: .top,
+                               endPoint: .bottom)
+                    .ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 24) {
+                        DashboardHeroCard(state: store.state,
+                                          lastChecked: store.lastCheckedDate,
+                                          baseURL: store.baseURLString,
+                                          isLoading: store.isChecking)
+
+                        quickActionsSection
+
+                        statusHighlightsSection
+
+                        HelpfulTipsCard()
                     }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 32)
                 }
             }
-            .listStyle(.insetGrouped)
-            .navigationTitle("Dashboard")
-            .refreshable {
-                await store.refresh()
+            .navigationTitle("Sprinkler")
+            .toolbar { refreshToolbarItem }
+            .refreshable { await store.refresh() }
+            .task { await store.refresh() }
+            .alert("Controller URL copied", isPresented: $showCopiedToast) {
+                Button("OK", role: .cancel) { showCopiedToast = false }
+            } message: {
+                Text("Share this address with anyone who needs access to the sprinkler controller.")
+            }
+            .onChange(of: scenePhase) { _, phase in
+                // Automatically refresh whenever the app becomes active so the dashboard
+                // always reflects the most recent controller state.
+                if phase == .active {
+                    Task { await store.refresh() }
+                }
             }
         }
-        .task {
-            await store.refresh()
+    }
+
+    /// Toolbar button that mirrors pull-to-refresh for discoverability.
+    private var refreshToolbarItem: some ToolbarContent {
+        ToolbarItem(placement: .navigationBarTrailing) {
+            Button {
+                Task { await store.refresh() }
+            } label: {
+                if store.isChecking {
+                    ProgressView()
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+            .accessibilityLabel("Refresh controller status")
         }
+    }
+
+    /// Section that houses contextual quick actions for the controller.
+    private var quickActionsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Quick Actions")
+                .font(.title3.weight(.semibold))
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(spacing: 12) {
+                QuickActionButton(title: store.isChecking ? "Checking…" : "Run Health Check",
+                                   subtitle: "Verifies that the controller is reachable right now.",
+                                   icon: "wave.3.left") {
+                    Task { await store.refresh() }
+                }
+                .disabled(store.isChecking)
+
+                QuickActionButton(title: "Copy Controller URL",
+                                   subtitle: "Share the configured address with another device.",
+                                   icon: "doc.on.doc") {
+                    copyAddressToPasteboard()
+                }
+            }
+        }
+    }
+
+    /// Section that highlights status information about connectivity and configuration.
+    private var statusHighlightsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Status Highlights")
+                .font(.title3.weight(.semibold))
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(spacing: 12) {
+                StatusHighlightCard(title: "Reachability",
+                                    icon: store.state.statusIcon,
+                                    tint: store.state.statusColor,
+                                    value: store.state.statusTitle,
+                                    detail: store.state.statusMessage)
+
+                if let lastChecked = store.lastCheckedDate {
+                    StatusHighlightCard(title: "Last Checked",
+                                        icon: "clock.badge.checkmark",
+                                        tint: .blue,
+                                        value: lastChecked.formatted(date: .omitted, time: .shortened),
+                                        detail: dashboardRelativeFormatter.localizedString(for: lastChecked, relativeTo: .now))
+                }
+
+                StatusHighlightCard(title: "Controller Address",
+                                    icon: "network",
+                                    tint: .teal,
+                                    value: store.baseURLString,
+                                    detail: "Tap copy above to share this address with others.")
+            }
+        }
+    }
+
+    /// Copies the configured controller address to the user's pasteboard with platform awareness.
+    private func copyAddressToPasteboard() {
+        #if os(iOS)
+        UIPasteboard.general.string = store.baseURLString
+        showCopiedToast = true
+        #elseif canImport(AppKit)
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(store.baseURLString, forType: .string)
+        showCopiedToast = true
+        #else
+        // Other platforms may not offer a convenient API; fall back to logging so developers
+        // still have visibility during testing.
+        print("Controller URL copied: \(store.baseURLString)")
+        #endif
+    }
+}
+
+// MARK: - Supporting Views
+
+/// A featured card that visualises the current connection state.
+private struct DashboardHeroCard: View {
+    let state: ConnectivityState
+    let lastChecked: Date?
+    let baseURL: String
+    let isLoading: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 12) {
+                ZStack {
+                    Circle()
+                        .fill(state.statusColor.opacity(0.2))
+                        .frame(width: 56, height: 56)
+                    Image(systemName: state.statusIcon)
+                        .font(.system(size: 24, weight: .semibold))
+                        .foregroundStyle(state.statusColor)
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(state.statusTitle)
+                        .font(.title2.weight(.bold))
+                        .foregroundStyle(.primary)
+                    Text(state.statusMessage)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .controlSize(.large)
+                }
+            }
+
+            Divider()
+                .overlay(Color.white.opacity(0.3))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Controller URL")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(baseURL)
+                    .font(.headline.monospaced())
+                    .foregroundStyle(.primary)
+                    .accessibilityLabel("Configured controller URL: \(baseURL)")
+
+                if let lastChecked {
+                    Text("Last updated \(dashboardRelativeFormatter.localizedString(for: lastChecked, relativeTo: .now))")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Run a health check to capture the latest status.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            LinearGradient(colors: [state.statusColor.opacity(0.25), Color.appSecondaryBackground],
+                           startPoint: .topLeading,
+                           endPoint: .bottomTrailing)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
+        .shadow(color: Color.black.opacity(0.1), radius: 12, x: 0, y: 8)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// Compact card used to display individual metrics or highlights.
+private struct StatusHighlightCard: View {
+    let title: String
+    let icon: String
+    let tint: Color
+    let value: String
+    let detail: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 12) {
+                Image(systemName: icon)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: 32, height: 32)
+                    .background(tint.opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text(detail)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Divider()
+                .background(Color.appSeparator)
+
+            Text(value)
+                .font(.body.monospaced())
+                .foregroundStyle(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.appBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// The reusable card-style button that drives the quick actions section.
+private struct QuickActionButton: View {
+    let title: String
+    let subtitle: String
+    let icon: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .center, spacing: 16) {
+                Image(systemName: icon)
+                    .font(.system(size: 22, weight: .semibold))
+                    .frame(width: 44, height: 44)
+                    .foregroundStyle(.white)
+                    .background(LinearGradient(colors: [Color.accentColor, Color.accentColor.opacity(0.6)],
+                                               startPoint: .topLeading,
+                                               endPoint: .bottomTrailing))
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.tertiaryLabel)
+            }
+            .padding(18)
+            .background(Color.appBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: 4)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// A lightweight card that surfaces contextual tips for maintaining connectivity.
+private struct HelpfulTipsCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Keep things running smoothly", systemImage: "lightbulb")
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 8) {
+                TipRow(text: "Ensure the Raspberry Pi remains on the same Wi-Fi network as your phone.")
+                TipRow(text: "Reserve the Pi's IP address on your router to avoid unexpected changes.")
+                TipRow(text: "Use the Settings tab to update the base URL whenever your network changes.")
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.appBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// Single row used inside the tips card to avoid repeating layout code.
+private struct TipRow: View {
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+            Text(text)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - Connectivity Helpers
+
+private extension ConnectivityState {
+    /// Machine readable title for the active connectivity state.
+    var statusTitle: String {
+        switch self {
+        case .connected:
+            return "Connected"
+        case .offline:
+            return "Offline"
+        }
+    }
+
+    /// A short message explaining the status in more detail for the hero card and highlight section.
+    var statusMessage: String {
+        switch self {
+        case .connected:
+            return "The controller is reachable on your network."
+        case let .offline(description):
+            return description ?? "Tap Run Health Check to troubleshoot the connection."
+        }
+    }
+
+    /// Symbol representing the current state.
+    var statusIcon: String {
+        switch self {
+        case .connected:
+            return "checkmark.seal"
+        case .offline:
+            return "exclamationmark.triangle"
+        }
+    }
+
+    /// Tint color that keeps the state consistent across the dashboard.
+    var statusColor: Color {
+        switch self {
+        case .connected:
+            return .green
+        case .offline:
+            return .orange
+        }
+    }
+}
+
+private extension Color {
+    /// Provides a fallback tertiary label color that works across platforms.
+    static var tertiaryLabel: Color {
+        #if os(iOS)
+        Color(UIColor.tertiaryLabel)
+        #elseif canImport(AppKit)
+        Color(NSColor.tertiaryLabelColor)
+        #else
+        Color.secondary
+        #endif
+    }
+
+    /// Normalised background color that respects the active platform's default surfaces.
+    static var appBackground: Color {
+        #if os(iOS)
+        Color(UIColor.systemBackground)
+        #elseif canImport(AppKit)
+        Color(NSColor.windowBackgroundColor)
+        #else
+        Color.white
+        #endif
+    }
+
+    /// Secondary background used for subtle contrast between cards and the canvas.
+    static var appSecondaryBackground: Color {
+        #if os(iOS)
+        Color(UIColor.secondarySystemBackground)
+        #elseif canImport(AppKit)
+        Color(NSColor.controlBackgroundColor)
+        #else
+        Color(white: 0.94)
+        #endif
+    }
+
+    /// Provides a sensible separator colour across platforms for card dividers.
+    static var appSeparator: Color {
+        #if os(iOS)
+        Color(UIColor.separator)
+        #elseif canImport(AppKit)
+        Color(NSColor.separatorColor)
+        #else
+        Color.gray.opacity(0.3)
+        #endif
     }
 }

--- a/SprinklerMobile/Views/SettingsView.swift
+++ b/SprinklerMobile/Views/SettingsView.swift
@@ -1,148 +1,378 @@
 import SwiftUI
+#if os(iOS)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
+/// Shared formatter to keep relative time strings consistent across the settings view.
+private let settingsRelativeFormatter: RelativeDateTimeFormatter = {
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .short
+    return formatter
+}()
+
+/// Settings screen redesigned around card-based sections for clarity and modern aesthetics.
 struct SettingsView: View {
     @EnvironmentObject private var store: ConnectivityStore
     @FocusState private var isURLFieldFocused: Bool
     @StateObject private var discoveryViewModel = DiscoveryViewModel()
+    @State private var showCopiedAlert = false
 
     var body: some View {
         NavigationStack {
-            Form {
-                Section("Sprinkler Controller") {
-                    TextField("http://sprinkler.local:8000", text: $store.baseURLString)
-                        .textInputAutocapitalization(.never)
-                        .keyboardType(.URL)
-                        .disableAutocorrection(true)
-                        .textContentType(.URL)
-                        .focused($isURLFieldFocused)
+            ZStack {
+                LinearGradient(colors: [Color.appBackground, Color.appSecondaryBackground],
+                               startPoint: .top,
+                               endPoint: .bottom)
+                    .ignoresSafeArea()
 
-                    Button(action: runHealthCheck) {
-                        if store.isChecking {
-                            ProgressView()
-                                .frame(maxWidth: .infinity)
-                        } else {
-                            Text("Test Connection")
-                                .frame(maxWidth: .infinity)
-                        }
+                ScrollView {
+                    VStack(spacing: 28) {
+                        SettingsHeroCard(state: store.state,
+                                         baseURL: store.baseURLString,
+                                         lastChecked: store.lastCheckedDate)
+
+                        ConnectionSettingsCard(baseURL: $store.baseURLString,
+                                               isChecking: store.isChecking,
+                                               state: store.state,
+                                               validationMessage: validationMessage,
+                                               focus: $isURLFieldFocused,
+                                               onCommit: runHealthCheck,
+                                               onCopy: copyAddressToPasteboard)
+
+                        DiscoveryCard(viewModel: discoveryViewModel,
+                                      onSelect: useDiscoveredDevice,
+                                      onRefresh: refreshDiscovery)
+
+                        HelpfulSettingsTipsCard()
                     }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isTestButtonDisabled)
-
-                    ConnectivityBadgeView(state: store.state, isLoading: store.isChecking)
-                        .accessibilityLabel(accessibilityLabel)
-                        .padding(.vertical, 4)
-
-                    if case let .offline(error?) = store.state {
-                        Text(error)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                            .accessibilityLabel("Connection error: \(error)")
-                    }
-                }
-
-                discoverySection
-
-                Section("Tips") {
-                    Text("Enter the Raspberry Pi's base URL once, then tap Test Connection to verify the sprinkler controller is reachable.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 32)
                 }
             }
             .navigationTitle("Settings")
-            .onAppear {
-                discoveryViewModel.start()
+            .toolbar { keyboardToolbar }
+            .alert("Controller URL copied", isPresented: $showCopiedAlert) {
+                Button("OK", role: .cancel) { showCopiedAlert = false }
+            } message: {
+                Text("You can now paste the sprinkler controller address wherever it's needed.")
             }
-            .onDisappear {
-                discoveryViewModel.stop()
-            }
+            .onAppear { discoveryViewModel.start() }
+            .onDisappear { discoveryViewModel.stop() }
         }
     }
 
+    /// Toolbar item that provides a convenient Done button for dismissing the keyboard.
+    private var keyboardToolbar: some ToolbarContent {
+        ToolbarItemGroup(placement: .keyboard) {
+            Spacer()
+            Button("Done") { isURLFieldFocused = false }
+        }
+    }
+
+    /// Consolidated validation message presented underneath the quick status badge.
+    private var validationMessage: String? {
+        switch store.state {
+        case .connected:
+            return nil
+        case let .offline(message):
+            return message
+        }
+    }
+
+    /// Triggers a connectivity test using the current address.
     private func runHealthCheck() {
         Task { await store.testConnection() }
     }
 
-    private var isTestButtonDisabled: Bool {
-        store.isChecking || store.baseURLString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    /// Applies the selected Bonjour device to the connection settings and tests immediately.
+    private func useDiscoveredDevice(_ device: DiscoveredDevice) {
+        isURLFieldFocused = false
+        store.baseURLString = device.baseURLString
+        runHealthCheck()
     }
 
-    private var accessibilityLabel: String {
-        switch store.state {
-        case .connected:
-            return "Controller connected"
-        case let .offline(description):
-            if let description {
-                return "Controller offline: \(description)"
+    /// Initiates another search for Bonjour services.
+    private func refreshDiscovery() {
+        isURLFieldFocused = false
+        discoveryViewModel.refresh()
+    }
+
+    /// Copies the configured address to the system pasteboard.
+    private func copyAddressToPasteboard() {
+        #if os(iOS)
+        UIPasteboard.general.string = store.baseURLString
+        showCopiedAlert = true
+        #elseif canImport(AppKit)
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(store.baseURLString, forType: .string)
+        showCopiedAlert = true
+        #else
+        print("Controller URL copied: \(store.baseURLString)")
+        #endif
+    }
+}
+
+// MARK: - Supporting Sections
+
+/// Hero card used to set the tone of the settings page with immediate feedback.
+private struct SettingsHeroCard: View {
+    let state: ConnectivityState
+    let baseURL: String
+    let lastChecked: Date?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Controller Overview")
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(.secondary)
+                Text("Stay connected to your sprinkler")
+                    .font(.title2.weight(.bold))
             }
-            return "Controller offline"
-        }
-    }
 
-    @ViewBuilder
-    private var discoverySection: some View {
-        Section {
-            if let message = discoveryViewModel.errorMessage {
+            HStack(alignment: .center, spacing: 12) {
+                Image(systemName: state.statusIcon)
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(state.statusColor)
+                    .frame(width: 60, height: 60)
+                    .background(state.statusColor.opacity(0.15))
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(state.statusTitle)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text(state.statusMessage)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Configured URL")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(baseURL)
+                    .font(.subheadline.monospaced())
+                    .foregroundStyle(.primary)
+
+                if let lastChecked {
+                    Text("Last checked \(settingsRelativeFormatter.localizedString(for: lastChecked, relativeTo: .now))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Run a health check to capture the current status.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.appBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .shadow(color: Color.black.opacity(0.08), radius: 10, x: 0, y: 6)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// Primary card that holds the controller address field and connectivity state.
+private struct ConnectionSettingsCard: View {
+    @Binding var baseURL: String
+    let isChecking: Bool
+    let state: ConnectivityState
+    let validationMessage: String?
+    let focus: FocusState<Bool>.Binding
+    let onCommit: () -> Void
+    let onCopy: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Controller Address")
+                .font(.headline)
+
+            Text("Provide the Raspberry Pi's HTTP base URL. We'll remember it for future sessions.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: 12) {
+                TextField("http://sprinkler.local:8000", text: $baseURL)
+                    .textInputAutocapitalization(.never)
+                    .keyboardType(.URL)
+                    .disableAutocorrection(true)
+                    .textContentType(.URL)
+                    .focused(focus)
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 16)
+                    .background(Color.appSecondaryBackground.opacity(0.6))
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                HStack(spacing: 12) {
+                    Button(action: onCommit) {
+                        if isChecking {
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                                .frame(maxWidth: .infinity)
+                        } else {
+                            Text("Test Connection")
+                                .fontWeight(.semibold)
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isChecking || baseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                    Button(action: onCopy) {
+                        Label("Copy", systemImage: "doc.on.doc")
+                            .font(.subheadline.weight(.medium))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(baseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+
+            ConnectivityBadgeView(state: state, isLoading: isChecking)
+
+            if let validationMessage, !validationMessage.isEmpty {
+                Text(validationMessage)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("Connection error: \(validationMessage)")
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.appBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// Displays discovered Bonjour devices in a stylised card.
+private struct DiscoveryCard: View {
+    @ObservedObject var viewModel: DiscoveryViewModel
+    let onSelect: (DiscoveredDevice) -> Void
+    let onRefresh: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .center) {
+                Text("Discovered Devices")
+                    .font(.headline)
+                Spacer()
+                if viewModel.isBrowsing {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            if let message = viewModel.errorMessage {
                 Text(message)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
 
-            if discoveryViewModel.devices.isEmpty {
-                if discoveryViewModel.isBrowsing {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("Searching your network…")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
+            if viewModel.devices.isEmpty {
+                Group {
+                    if viewModel.isBrowsing {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Searching your network…")
+                        }
+                    } else if viewModel.errorMessage == nil {
+                        Text("No sprinkler controllers discovered yet. Tap Refresh to try again.")
                     }
-                } else if discoveryViewModel.errorMessage == nil {
-                    Text("No sprinkler controllers discovered yet. Tap Refresh to search again.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
                 }
-            }
-
-            ForEach(discoveryViewModel.devices) { device in
-                Button {
-                    isURLFieldFocused = false
-                    store.baseURLString = device.baseURLString
-                    runHealthCheck()
-                } label: {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(device.name.isEmpty ? "sprinkler" : device.name)
-                            .font(.body)
-                        let subtitle = deviceSubtitle(for: device)
-                        Text(subtitle)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            } else {
+                VStack(spacing: 12) {
+                    ForEach(viewModel.devices) { device in
+                        Button {
+                            onSelect(device)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(device.name.isEmpty ? "sprinkler" : device.name)
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(.primary)
+                                Text(deviceSubtitle(for: device))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(16)
+                            .background(Color.appSecondaryBackground.opacity(0.5))
+                            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
 
             HStack {
                 Spacer()
-                Button("Refresh") {
-                    isURLFieldFocused = false
-                    discoveryViewModel.refresh()
-                }
-                .disabled(discoveryViewModel.isBrowsing)
-            }
-        } header: {
-            HStack {
-                Text("Discovered Devices")
-                Spacer()
-                if discoveryViewModel.isBrowsing {
-                    ProgressView()
-                        .controlSize(.small)
-                }
+                Button("Refresh", action: onRefresh)
+                    .disabled(viewModel.isBrowsing)
             }
         }
+        .padding(24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.appBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: 4)
+        .accessibilityElement(children: .combine)
     }
 
     private func deviceSubtitle(for device: DiscoveredDevice) -> String {
         let endpoint = device.host ?? device.ip ?? "—"
         return "\(endpoint):\(device.port)"
+    }
+}
+
+/// Reinforces best practices for keeping connectivity stable.
+private struct HelpfulSettingsTipsCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Helpful Tips", systemImage: "info.circle")
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 8) {
+                TipRow(text: "Double-check that the Raspberry Pi stays powered and connected to your LAN.")
+                TipRow(text: "Update this URL if you move to a new network or change routers.")
+                TipRow(text: "Restrict access to trusted devices and keep your token secure.")
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.appBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// Single tip row reused within the settings tips card.
+private struct TipRow: View {
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+            Text(text)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
     }
 }


### PR DESCRIPTION
## Summary
- rebuild the dashboard with card-based hero, status highlights, and quick actions while supporting copy-to-clipboard flows
- restyle the settings screen around modern cards, inline discovery, and clipboard support with consistent relative time formatting
- expose the last connection check timestamp in `ConnectivityStore` and tint the main tab interface for a cohesive theme

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ccde500c208331b04b80eaf141eb28