### PR TITLE
Fix iOS build metadata and colors

### DIFF
--- a/Sprink.xcodeproj/project.pbxproj
+++ b/Sprink.xcodeproj/project.pbxproj
@@ -453,7 +453,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+                                TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sprink.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Sprink";
 			};
 			name = Debug;
@@ -471,7 +471,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+                                TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sprink.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Sprink";
 			};
 			name = Release;
@@ -529,7 +529,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = SprinklerApp/SprinklerMobile/Resources/Info.plist;
+                                INFOPLIST_FILE = SprinklerMobile/Resources/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -588,7 +588,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = SprinklerApp/SprinklerMobile/Resources/Info.plist;
+                                INFOPLIST_FILE = SprinklerMobile/Resources/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -610,9 +610,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = SprinklerMobile/Resources/Info.plist;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -624,7 +623,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+                                TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -639,9 +638,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = SprinklerMobile/Resources/Info.plist;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -653,7 +651,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+                                TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/SprinklerMobile/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SprinklerMobile/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,24 +1,53 @@
 {
   "images": [
     {
-      "idiom": "universal",
-      "filename": "AppIcon.pdf",
-      "platform": "ios",
-      "size": "1024x1024"
+      "idiom": "iphone",
+      "scale": "2x",
+      "size": "20x20"
+    },
+    {
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "20x20"
+    },
+    {
+      "idiom": "iphone",
+      "scale": "2x",
+      "size": "29x29"
+    },
+    {
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "29x29"
+    },
+    {
+      "idiom": "iphone",
+      "scale": "2x",
+      "size": "40x40"
+    },
+    {
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "40x40"
+    },
+    {
+      "idiom": "iphone",
+      "scale": "2x",
+      "size": "60x60"
+    },
+    {
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "60x60"
     },
     {
       "idiom": "ios-marketing",
-      "filename": "AppIcon.pdf",
-      "size": "1024x1024",
-      "scale": "1x"
+      "scale": "1x",
+      "size": "1024x1024"
     }
   ],
   "info": {
-    "version": 1,
-    "author": "xcode"
-  },
-  "properties": {
-    "preserves-vector-representation": true,
-    "pre-rendered": true
+    "author": "xcode",
+    "version": 1
   }
 }

--- a/SprinklerMobile/Resources/Info.plist
+++ b/SprinklerMobile/Resources/Info.plist
@@ -16,6 +16,8 @@
   <string>1.0</string>
   <key>CFBundleVersion</key>
   <string>1</string>
+  <key>UILaunchStoryboardName</key>
+  <string>LaunchScreen</string>
 
   <key>NSBonjourServices</key>
   <array>
@@ -29,10 +31,5 @@
     <key>NSAllowsArbitraryLoadsInLocalNetworks</key>
     <true/>
   </dict>
-  <key>UIDeviceFamily</key>
-  <array>
-    <integer>1</integer>
-    <integer>2</integer>
-  </array>
 </dict>
 </plist>

--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -308,7 +308,7 @@ private struct QuickActionButton: View {
 
                 Image(systemName: "chevron.right")
                     .font(.body.weight(.semibold))
-                    .foregroundStyle(.tertiaryLabel)
+                    .foregroundStyle(.tertiary)
             }
             .padding(18)
             .background(Color.appBackground)
@@ -404,17 +404,6 @@ private extension ConnectivityState {
 }
 
 private extension Color {
-    /// Provides a fallback tertiary label color that works across platforms.
-    static var tertiaryLabel: Color {
-        #if os(iOS)
-        Color(UIColor.tertiaryLabel)
-        #elseif canImport(AppKit)
-        Color(NSColor.tertiaryLabelColor)
-        #else
-        Color.secondary
-        #endif
-    }
-
     /// Normalised background color that respects the active platform's default surfaces.
     static var appBackground: Color {
         #if os(iOS)


### PR DESCRIPTION
## Summary
- update DashboardView to rely on SwiftUI's tertiary hierarchical style
- clean up the AppIcon asset catalog to remove PDF-based icons
- align Info.plist contents and Xcode build settings for a device-ready iPhone build

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cce23046d08331900c0e7c7ec1ffec