### PR TITLE
Add theme colors and connectivity presentation helpers

### DIFF
--- a/SprinklerMobile/Stores/ConnectivityState+Presentation.swift
+++ b/SprinklerMobile/Stores/ConnectivityState+Presentation.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+extension ConnectivityState {
+    /// SF Symbol appropriate for the state.
+    var statusIcon: String {
+        switch self {
+        case .connected: return "checkmark.circle.fill"
+        case .offline:   return "xmark.circle.fill"
+        }
+    }
+
+    /// Short, user-facing title.
+    var statusTitle: String {
+        switch self {
+        case .connected: return "Connected"
+        case .offline:   return "Offline"
+        }
+    }
+
+    /// Optional detail (surfaces the error if present).
+    var statusMessage: String? {
+        switch self {
+        case .connected: return nil
+        case .offline(let message): return message
+        }
+    }
+
+    /// Accent color for icons/text.
+    var statusColor: Color {
+        switch self {
+        case .connected: return .green
+        case .offline:   return .red
+        }
+    }
+}

--- a/SprinklerMobile/Utils/Theme.swift
+++ b/SprinklerMobile/Utils/Theme.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+/// Centralized app colors backed by Apple semantic colors.
+extension Color {
+    /// Primary window background (adapts to light/dark, vibrancy, etc.)
+    static let appBackground = Color(.systemBackground)
+
+    /// Secondary group/card background
+    static let appSecondaryBackground = Color(.secondarySystemBackground)
+
+    /// Subtle separator color
+    static let appSeparator = Color(.separator)
+}


### PR DESCRIPTION
## Summary
- add a reusable theme extension exposing app background, secondary background, and separator colors via SwiftUI
- extend ConnectivityState with status presentation helpers used by dashboard and settings views

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68cd5f7b5a708331abae2d34c7234073