### PR TITLE
Add connectivity presentation helpers to Sprink! target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,8 @@ let package = Package(
                 "Utils",
                 "Views",
                 "SprinklerMobileApp.swift",
-                "Stores/SprinklerStore.swift"
+                "Stores/SprinklerStore.swift",
+                "Stores/ConnectivityState+Presentation.swift"
             ],
             sources: [
                 "Models/DiscoveredDevice.swift",

--- a/Sprink.xcodeproj/project.pbxproj
+++ b/Sprink.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+               AAA5C1E62E8D2F9000C533F1 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA5C1E52E8D2F9000C533F1 /* Theme.swift */; };
+               AAA5C1E82E8D2F9000C533F1 /* ConnectivityState+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA5C1E72E8D2F9000C533F1 /* ConnectivityState+Presentation.swift */; };
 		6208745A2E7D04D80062F269 /* BonjourDiscoveryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB8A2E7C7DCF001856FD /* BonjourDiscoveryServiceTests.swift */; };
 		6208745B2E7D04DD0062F269 /* ConnectivityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB8B2E7C7DCF001856FD /* ConnectivityStoreTests.swift */; };
 		6208745C2E7D04E30062F269 /* HealthCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB8C2E7C7DCF001856FD /* HealthCheckerTests.swift */; };
@@ -58,6 +60,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+               AAA5C1E52E8D2F9000C533F1 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+               AAA5C1E72E8D2F9000C533F1 /* ConnectivityState+Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectivityState+Presentation.swift"; sourceTree = "<group>"; };
 		620874512E7D04C10062F269 /* SprinklerConnectivityTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SprinklerConnectivityTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		621360EF2E7C8AE30094E4D2 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		621360F22E7C8C730094E4D2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -197,22 +201,24 @@
 			path = Services;
 			sourceTree = "<group>";
 		};
-		6251FB762E7C7DCF001856FD /* Stores */ = {
-			isa = PBXGroup;
-			children = (
-				6251FB742E7C7DCF001856FD /* ConnectivityStore.swift */,
-				6251FB752E7C7DCF001856FD /* SprinklerStore.swift */,
-			);
-			path = Stores;
-			sourceTree = "<group>";
-		};
-		6251FB7B2E7C7DCF001856FD /* Utils */ = {
-			isa = PBXGroup;
-			children = (
-				6251FB772E7C7DCF001856FD /* KeychainStorage.swift */,
-				6251FB782E7C7DCF001856FD /* SkeletonView.swift */,
-				6251FB792E7C7DCF001856FD /* Toast.swift */,
-				6251FB7A2E7C7DCF001856FD /* Validators.swift */,
+               6251FB762E7C7DCF001856FD /* Stores */ = {
+                       isa = PBXGroup;
+                       children = (
+                               6251FB742E7C7DCF001856FD /* ConnectivityStore.swift */,
+                               AAA5C1E72E8D2F9000C533F1 /* ConnectivityState+Presentation.swift */,
+                               6251FB752E7C7DCF001856FD /* SprinklerStore.swift */,
+                       );
+                       path = Stores;
+                       sourceTree = "<group>";
+               };
+               6251FB7B2E7C7DCF001856FD /* Utils */ = {
+                       isa = PBXGroup;
+                       children = (
+                               AAA5C1E52E8D2F9000C533F1 /* Theme.swift */,
+                               6251FB772E7C7DCF001856FD /* KeychainStorage.swift */,
+                               6251FB782E7C7DCF001856FD /* SkeletonView.swift */,
+                               6251FB792E7C7DCF001856FD /* Toast.swift */,
+                               6251FB7A2E7C7DCF001856FD /* Validators.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -390,13 +396,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		6251FB3E2E7C7D3F001856FD /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6251FB8F2E7C7DCF001856FD /* RainDTO.swift in Sources */,
-				6251FB902E7C7DCF001856FD /* ConnectivityBadgeView.swift in Sources */,
-				6251FB912E7C7DCF001856FD /* SkeletonView.swift in Sources */,
-				6251FB932E7C7DCF001856FD /* HTTPClient.swift in Sources */,
+                       isa = PBXSourcesBuildPhase;
+                       buildActionMask = 2147483647;
+                       files = (
+                               AAA5C1E82E8D2F9000C533F1 /* ConnectivityState+Presentation.swift in Sources */,
+                               6251FB8F2E7C7DCF001856FD /* RainDTO.swift in Sources */,
+                               6251FB902E7C7DCF001856FD /* ConnectivityBadgeView.swift in Sources */,
+                               6251FB912E7C7DCF001856FD /* SkeletonView.swift in Sources */,
+                               6251FB932E7C7DCF001856FD /* HTTPClient.swift in Sources */,
 				6251FB942E7C7DCF001856FD /* BonjourDiscoveryService.swift in Sources */,
 				6251FB962E7C7DCF001856FD /* StatusDTO.swift in Sources */,
 				6251FB972E7C7DCF001856FD /* KeychainStorage.swift in Sources */,
@@ -412,13 +419,14 @@
 				6251FBA22E7C7DCF001856FD /* SSLPinningDelegate.swift in Sources */,
 				6251FBA32E7C7DCF001856FD /* ScheduleRowView.swift in Sources */,
 				6251FBA42E7C7DCF001856FD /* DiscoveredDevice.swift in Sources */,
-				6251FBA52E7C7DCF001856FD /* SchedulesView.swift in Sources */,
-				6251FBA62E7C7DCF001856FD /* SettingsView.swift in Sources */,
-				6251FBA72E7C7DCF001856FD /* GPIOCatalog.swift in Sources */,
-				6251FBA82E7C7DCF001856FD /* ScheduleDTO.swift in Sources */,
-				6251FBA92E7C7DCF001856FD /* APIClient.swift in Sources */,
-				6251FBAA2E7C7DCF001856FD /* DashboardView.swift in Sources */,
-				6251FBAC2E7C7DCF001856FD /* HealthChecker.swift in Sources */,
+                               6251FBA52E7C7DCF001856FD /* SchedulesView.swift in Sources */,
+                               6251FBA62E7C7DCF001856FD /* SettingsView.swift in Sources */,
+                               6251FBA72E7C7DCF001856FD /* GPIOCatalog.swift in Sources */,
+                               6251FBA82E7C7DCF001856FD /* ScheduleDTO.swift in Sources */,
+                               6251FBA92E7C7DCF001856FD /* APIClient.swift in Sources */,
+                               6251FBAA2E7C7DCF001856FD /* DashboardView.swift in Sources */,
+                               AAA5C1E62E8D2F9000C533F1 /* Theme.swift in Sources */,
+                               6251FBAC2E7C7DCF001856FD /* HealthChecker.swift in Sources */,
 				6251FBAD2E7C7DCF001856FD /* PinDTO.swift in Sources */,
 				6251FBAE2E7C7DCF001856FD /* ScheduleGroupDTO.swift in Sources */,
 				6251FBAF2E7C7DCF001856FD /* DiscoveryViewModel.swift in Sources */,

--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -179,10 +179,12 @@ private struct DashboardHeroCard: View {
                     Text(state.statusTitle)
                         .font(.title2.weight(.bold))
                         .foregroundStyle(.primary)
-                    Text(state.statusMessage)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                    if let message = state.statusMessage {
+                        Text(message)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
 
                 Spacer()
@@ -236,7 +238,7 @@ private struct StatusHighlightCard: View {
     let icon: String
     let tint: Color
     let value: String
-    let detail: String
+    let detail: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -252,9 +254,11 @@ private struct StatusHighlightCard: View {
                     Text(title)
                         .font(.headline)
                         .foregroundStyle(.primary)
-                    Text(detail)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                    if let detail {
+                        Text(detail)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
 

--- a/SprinklerMobile/Views/SettingsView.swift
+++ b/SprinklerMobile/Views/SettingsView.swift
@@ -145,10 +145,12 @@ private struct SettingsHeroCard: View {
                     Text(state.statusTitle)
                         .font(.headline)
                         .foregroundStyle(.primary)
-                    Text(state.statusMessage)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                    if let message = state.statusMessage {
+                        Text(message)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
 
                 Spacer()


### PR DESCRIPTION
## Summary
- add the Theme and ConnectivityState presentation helpers to the Sprink! iOS target build phase
- update DashboardView and SettingsView to tolerate optional connectivity messages when the controller is online
- exclude the presentation helper from the SwiftPM manifest so package builds stay unchanged

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cd62cfaac48331910eb8a7637f1316