### PR TITLE
Revamp dashboard layout with schedule and pin controls

### DIFF
--- a/SprinklerMobile/SprinklerMobileApp.swift
+++ b/SprinklerMobile/SprinklerMobileApp.swift
@@ -3,11 +3,13 @@ import SwiftUI
 @main
 struct SprinklerMobileApp: App {
     @StateObject private var connectivityStore = ConnectivityStore()
+    @StateObject private var sprinklerStore = SprinklerStore()
 
     var body: some Scene {
         WindowGroup {
             RootView()
                 .environmentObject(connectivityStore)
+                .environmentObject(sprinklerStore)
         }
     }
 }


### PR DESCRIPTION
## Summary
- redesign the dashboard into LED, schedule, pin control, and rain status panels with reusable views
- compute current and upcoming schedule runs along with timed pin activation support in the sprinkler store
- wire the sprinkler store into the app entry point so the dashboard can access live controller data

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68cd861ebaec8331a5694a7bb62665ef