### PR TITLE
Add ShapeStyle bridge for theme colors

### DIFF
--- a/SprinklerMobile/Utils/Color+Theme.swift
+++ b/SprinklerMobile/Utils/Color+Theme.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Provides ShapeStyle accessors for theme colour tokens so that `.foregroundStyle(.token)`
+/// and similar APIs compile across the codebase. The computed properties simply forward to
+/// the canonical definitions declared in `Theme.swift`.
+extension ShapeStyle where Self == Color {
+    /// Primary canvas colour used for top-level backgrounds.
+    static var appPrimaryBackground: Color { .appPrimaryBackground }
+
+    /// Secondary surface colour for grouped content.
+    static var appSecondaryBackground: Color { .appSecondaryBackground }
+
+    /// Elevated background applied to cards.
+    static var appCardBackground: Color { .appCardBackground }
+
+    /// Highlight colour used for card gradients.
+    static var appCardBackgroundElevated: Color { .appCardBackgroundElevated }
+
+    /// High-contrast stroke colour for cards.
+    static var appCardStroke: Color { .appCardStroke }
+
+    /// Divider colour for separators.
+    static var appSeparator: Color { .appSeparator }
+
+    /// Primary accent colour.
+    static var appAccentPrimary: Color { .appAccentPrimary }
+
+    /// Secondary accent colour.
+    static var appAccentSecondary: Color { .appAccentSecondary }
+
+    /// Success state colour.
+    static var appSuccess: Color { .appSuccess }
+
+    /// Warning state colour.
+    static var appWarning: Color { .appWarning }
+
+    /// Danger state colour.
+    static var appDanger: Color { .appDanger }
+
+    /// Informational blue used for neutral messaging.
+    static var appInfo: Color { .appInfo }
+
+    /// Ambient shadow colour tuned for translucency.
+    static var appShadow: Color { .appShadow }
+
+    /// Top gradient colour for canvas backgrounds.
+    static var appCanvasTop: Color { .appCanvasTop }
+
+    /// Bottom gradient colour for canvas backgrounds.
+    static var appCanvasBottom: Color { .appCanvasBottom }
+
+    /// Legacy alias maintained for backwards compatibility while the codebase migrates to
+    /// the refreshed theme.
+    static var appBackground: Color { .appBackground }
+}


### PR DESCRIPTION
## Summary
- add a SwiftUI ShapeStyle extension that exposes the existing theme color tokens
- allow view modifiers such as `.foregroundStyle(.appInfo)` to compile without changing call sites

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd8c801e748331a436535d30fe1739