### PR TITLE
Fix ShapeStyle theme accessors to avoid recursion

### DIFF
--- a/SprinklerMobile/Utils/Color+Theme.swift
+++ b/SprinklerMobile/Utils/Color+Theme.swift
@@ -5,51 +5,51 @@ import SwiftUI
 /// the canonical definitions declared in `Theme.swift`.
 extension ShapeStyle where Self == Color {
     /// Primary canvas colour used for top-level backgrounds.
-    static var appPrimaryBackground: Color { .appPrimaryBackground }
+    static var appPrimaryBackground: Color { Color.appPrimaryBackground }
 
     /// Secondary surface colour for grouped content.
-    static var appSecondaryBackground: Color { .appSecondaryBackground }
+    static var appSecondaryBackground: Color { Color.appSecondaryBackground }
 
     /// Elevated background applied to cards.
-    static var appCardBackground: Color { .appCardBackground }
+    static var appCardBackground: Color { Color.appCardBackground }
 
     /// Highlight colour used for card gradients.
-    static var appCardBackgroundElevated: Color { .appCardBackgroundElevated }
+    static var appCardBackgroundElevated: Color { Color.appCardBackgroundElevated }
 
     /// High-contrast stroke colour for cards.
-    static var appCardStroke: Color { .appCardStroke }
+    static var appCardStroke: Color { Color.appCardStroke }
 
     /// Divider colour for separators.
-    static var appSeparator: Color { .appSeparator }
+    static var appSeparator: Color { Color.appSeparator }
 
     /// Primary accent colour.
-    static var appAccentPrimary: Color { .appAccentPrimary }
+    static var appAccentPrimary: Color { Color.appAccentPrimary }
 
     /// Secondary accent colour.
-    static var appAccentSecondary: Color { .appAccentSecondary }
+    static var appAccentSecondary: Color { Color.appAccentSecondary }
 
     /// Success state colour.
-    static var appSuccess: Color { .appSuccess }
+    static var appSuccess: Color { Color.appSuccess }
 
     /// Warning state colour.
-    static var appWarning: Color { .appWarning }
+    static var appWarning: Color { Color.appWarning }
 
     /// Danger state colour.
-    static var appDanger: Color { .appDanger }
+    static var appDanger: Color { Color.appDanger }
 
     /// Informational blue used for neutral messaging.
-    static var appInfo: Color { .appInfo }
+    static var appInfo: Color { Color.appInfo }
 
     /// Ambient shadow colour tuned for translucency.
-    static var appShadow: Color { .appShadow }
+    static var appShadow: Color { Color.appShadow }
 
     /// Top gradient colour for canvas backgrounds.
-    static var appCanvasTop: Color { .appCanvasTop }
+    static var appCanvasTop: Color { Color.appCanvasTop }
 
     /// Bottom gradient colour for canvas backgrounds.
-    static var appCanvasBottom: Color { .appCanvasBottom }
+    static var appCanvasBottom: Color { Color.appCanvasBottom }
 
     /// Legacy alias maintained for backwards compatibility while the codebase migrates to
     /// the refreshed theme.
-    static var appBackground: Color { .appBackground }
+    static var appBackground: Color { Color.appBackground }
 }


### PR DESCRIPTION
## Summary
- fix each ShapeStyle theme accessor to explicitly reference the Color namespace
- prevent infinite recursion that previously caused ShapeStyle.app* members to be missing at compile time

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cd934561cc83319aa99067838fd303