### PR TITLE
Use Color.appInfo bridge for dashboard status label

### DIFF
--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -564,7 +564,7 @@ private struct PinControlRow: View {
                 if isActive {
                     Text("Running…")
                         .font(.appCaption)
-                        .foregroundStyle(.appInfo)
+                        .foregroundStyle(Color.appInfo)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- replace the informational foreground style call site in DashboardView with the Color.appInfo shim to unblock builds lacking the ShapeStyle bridge

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cd96856cfc8331ac50008ccc64b726