### PR TITLE
Support sequence-based schedules

### DIFF
--- a/SprinklerMobile/Data/ScheduleDTO.swift
+++ b/SprinklerMobile/Data/ScheduleDTO.swift
@@ -3,17 +3,66 @@ import Foundation
 struct ScheduleDTO: Codable, Identifiable, Hashable {
     let id: String
     let name: String?
-    let durationMinutes: Int?
     let startTime: String?
     let days: [String]?
     let isEnabled: Bool?
+    let durationMinutes: Int?
+    let sequence: [ScheduleSequenceItemDTO]?
 
     enum CodingKeys: String, CodingKey {
         case id
         case name
-        case durationMinutes = "duration"
         case startTime = "start_time"
         case days
         case isEnabled = "is_enabled"
+        case durationMinutes = "duration"
+        case sequence
+    }
+}
+
+/// Describes a single step in a watering sequence, pairing a physical pin with its
+/// runtime. The backend encodes these values using the `duration` key to preserve
+/// compatibility with the previous payload shape.
+struct ScheduleSequenceItemDTO: Codable, Hashable {
+    let pin: Int
+    let durationMinutes: Int
+
+    enum CodingKeys: String, CodingKey {
+        case pin
+        case durationMinutes = "duration"
+    }
+}
+
+extension ScheduleDTO {
+    /// Resolves the effective sequence for this schedule, falling back to applying the
+    /// legacy single duration to the provided default pins when the backend has not yet
+    /// transitioned to per-pin durations.
+    /// - Parameter defaultPins: Pins sourced from the controller. Enabled pins are
+    ///   preferred, but the method will gracefully fall back to the provided list to
+    ///   ensure every legacy schedule continues to run.
+    /// - Returns: Ordered sequence of pin/duration pairs.
+    func resolvedSequence(defaultPins: [PinDTO]) -> [ScheduleSequenceItemDTO] {
+        if let sequence, !sequence.isEmpty {
+            return sequence
+        }
+
+        let normalizedDuration = max(durationMinutes ?? 0, 0)
+        guard !defaultPins.isEmpty else { return [] }
+
+        let enabledPins = defaultPins.filter { $0.isEnabled ?? true }
+        let pinsToUse = enabledPins.isEmpty ? defaultPins : enabledPins
+        return pinsToUse.map { pin in
+            ScheduleSequenceItemDTO(pin: pin.pin, durationMinutes: normalizedDuration)
+        }
+    }
+
+    /// Calculates the total runtime for the schedule by summing each sequence step.
+    /// - Parameter defaultPins: Pins used to infer the sequence for legacy payloads.
+    /// - Returns: Total number of minutes the schedule will run.
+    func totalDuration(defaultPins: [PinDTO]) -> Int {
+        resolvedSequence(defaultPins: defaultPins)
+            .reduce(0) { partialResult, item in
+                partialResult + max(item.durationMinutes, 0)
+            }
     }
 }

--- a/SprinklerMobile/Data/ScheduleDraft.swift
+++ b/SprinklerMobile/Data/ScheduleDraft.swift
@@ -1,43 +1,116 @@
 import Foundation
 
 struct ScheduleDraft: Identifiable, Equatable {
+    struct Step: Identifiable, Equatable {
+        var id: UUID
+        var pin: Int
+        var durationMinutes: Int
+
+        init(id: UUID = UUID(), pin: Int, durationMinutes: Int) {
+            self.id = id
+            self.pin = pin
+            self.durationMinutes = durationMinutes
+        }
+    }
+
     var id: String
     var name: String
-    var durationMinutes: Int
     var startTime: String
     var days: [String]
     var isEnabled: Bool
+    var sequence: [Step]
 
     init(id: String = UUID().uuidString,
          name: String = "",
-         durationMinutes: Int = 10,
          startTime: String = "06:00",
          days: [String] = [],
-         isEnabled: Bool = true) {
+         isEnabled: Bool = true,
+         sequence: [Step] = [],
+         pins: [PinDTO] = []) {
         self.id = id
         self.name = name
-        self.durationMinutes = durationMinutes
         self.startTime = startTime
         self.days = days
         self.isEnabled = isEnabled
+        if sequence.isEmpty {
+            let resolvedPins = pins.filter { $0.isEnabled ?? true }
+            let seeds = resolvedPins.isEmpty ? pins : resolvedPins
+            self.sequence = seeds.map { Step(pin: $0.pin, durationMinutes: Self.defaultDurationMinutes) }
+        } else {
+            self.sequence = sequence
+        }
     }
 
-    init(schedule: ScheduleDTO) {
+    init(schedule: ScheduleDTO, pins: [PinDTO] = []) {
         self.id = schedule.id
         self.name = schedule.name ?? ""
-        self.durationMinutes = schedule.durationMinutes ?? 10
         self.startTime = schedule.startTime ?? "06:00"
         self.days = schedule.days ?? []
         self.isEnabled = schedule.isEnabled ?? true
+        let resolvedSequence = schedule.resolvedSequence(defaultPins: pins)
+        if resolvedSequence.isEmpty, let firstPin = pins.first {
+            self.sequence = [Step(pin: firstPin.pin,
+                                   durationMinutes: schedule.durationMinutes ?? Self.defaultDurationMinutes)]
+        } else {
+            self.sequence = resolvedSequence.map { item in
+                Step(pin: item.pin, durationMinutes: item.durationMinutes)
+            }
+        }
     }
 
     var payload: ScheduleWritePayload {
-        ScheduleWritePayload(name: name.isEmpty ? nil : name,
-                             durationMinutes: durationMinutes,
-                             startTime: startTime,
-                             days: days.isEmpty ? nil : days,
-                             isEnabled: isEnabled)
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sanitizedSequence = sequence.map { step -> Step in
+            var copy = step
+            copy.durationMinutes = max(copy.durationMinutes, 0)
+            return copy
+        }
+        let fallbackDuration = sanitizedSequence.first?.durationMinutes ?? Self.defaultDurationMinutes
+        return ScheduleWritePayload(name: trimmedName.isEmpty ? nil : trimmedName,
+                                    durationMinutes: fallbackDuration,
+                                    startTime: startTime,
+                                    days: days.isEmpty ? nil : days,
+                                    isEnabled: isEnabled,
+                                    sequence: sanitizedSequence.map { step in
+                                        ScheduleWritePayload.Step(pin: step.pin,
+                                                                  durationMinutes: step.durationMinutes)
+                                    })
     }
+
+    mutating func addSteps(for pins: [PinDTO]) {
+        let existingPins = Set(sequence.map(\.pin))
+        let defaultDuration = sequence.first?.durationMinutes ?? Self.defaultDurationMinutes
+        let additions = pins.filter { !existingPins.contains($0.pin) }
+        sequence.append(contentsOf: additions.map { pin in
+            Step(pin: pin.pin, durationMinutes: defaultDuration)
+        })
+    }
+
+    mutating func addStep(for pin: PinDTO) {
+        guard !sequence.contains(where: { $0.pin == pin.pin }) else { return }
+        let defaultDuration = sequence.first?.durationMinutes ?? Self.defaultDurationMinutes
+        sequence.append(Step(pin: pin.pin, durationMinutes: defaultDuration))
+    }
+
+    mutating func removeSteps(at offsets: IndexSet) {
+        for offset in offsets.sorted(by: >) {
+            guard sequence.indices.contains(offset) else { continue }
+            sequence.remove(at: offset)
+        }
+    }
+
+    mutating func moveSteps(from offsets: IndexSet, to destination: Int) {
+        let items = offsets.compactMap { index -> Step? in
+            guard sequence.indices.contains(index) else { return nil }
+            return sequence[index]
+        }
+        removeSteps(at: offsets)
+        let adjustedDestination = destination - offsets.filter { $0 < destination }.count
+        let clampedDestination = max(0, min(adjustedDestination, sequence.count))
+        sequence.insert(contentsOf: items, at: clampedDestination)
+    }
+
+    private static let defaultDurationMinutes = 10
 }
 
 /// Payload used when creating or updating a schedule via the controller API.
@@ -47,6 +120,17 @@ struct ScheduleWritePayload: Encodable {
     let startTime: String
     let days: [String]?
     let isEnabled: Bool
+    let sequence: [Step]
+
+    struct Step: Encodable, Equatable {
+        let pin: Int
+        let durationMinutes: Int
+
+        enum CodingKeys: String, CodingKey {
+            case pin
+            case durationMinutes = "duration"
+        }
+    }
 
     enum CodingKeys: String, CodingKey {
         case name
@@ -54,5 +138,6 @@ struct ScheduleWritePayload: Encodable {
         case startTime = "start_time"
         case days
         case isEnabled = "is_enabled"
+        case sequence
     }
 }

--- a/SprinklerMobile/Views/ScheduleEditorView.swift
+++ b/SprinklerMobile/Views/ScheduleEditorView.swift
@@ -2,36 +2,47 @@ import SwiftUI
 
 struct ScheduleEditorView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var store: SprinklerStore
     @State private var draft: ScheduleDraft
+    @State private var timeSelection: Date
     let onSave: (ScheduleDraft) -> Void
 
     private let dayOptions = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
+    private var pinsByNumber: [Int: PinDTO] {
+        Dictionary(uniqueKeysWithValues: store.pins.map { ($0.pin, $0) })
+    }
+
+    private var activePins: [PinDTO] {
+        store.activePins
+    }
+
+    private var missingActivePins: [PinDTO] {
+        let assignedPins = Set(draft.sequence.map(\.pin))
+        return activePins.filter { !assignedPins.contains($0.pin) }
+    }
+
+    private var inactiveSteps: [ScheduleDraft.Step] {
+        draft.sequence.filter { step in
+            !(pinsByNumber[step.pin]?.isEnabled ?? true)
+        }
+    }
+
     init(draft: ScheduleDraft, onSave: @escaping (ScheduleDraft) -> Void) {
-        _draft = State(initialValue: draft)
+        var workingDraft = draft
+        let parsedTime = ScheduleEditorView.date(from: draft.startTime) ?? ScheduleEditorView.defaultTime
+        workingDraft.startTime = ScheduleEditorView.timeString(from: parsedTime)
+        _draft = State(initialValue: workingDraft)
+        _timeSelection = State(initialValue: parsedTime)
         self.onSave = onSave
     }
 
     var body: some View {
         NavigationStack {
             Form {
-                Section("Details") {
-                    TextField("Name", text: $draft.name)
-                    Stepper(value: $draft.durationMinutes, in: 1...180, step: 1) {
-                        Text("Duration: \(draft.durationMinutes) min")
-                    }
-                    TextField("Start (HH:mm)", text: $draft.startTime)
-                        .keyboardType(.numbersAndPunctuation)
-                    Toggle("Enabled", isOn: $draft.isEnabled)
-                }
-
-                Section("Days") {
-                    ForEach(dayOptions, id: \.self) { day in
-                        MultipleSelectionRow(title: day, isSelected: draft.days.contains(day)) {
-                            toggle(day: day)
-                        }
-                    }
-                }
+                detailsSection
+                daysSection
+                sequenceSection
             }
             .navigationTitle("Schedule")
             .toolbar {
@@ -43,10 +54,97 @@ struct ScheduleEditorView: View {
                         onSave(draft)
                         dismiss()
                     }
-                    .disabled(draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .disabled(!isDraftSavable)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if !draft.sequence.isEmpty {
+                        EditButton()
+                    }
+                }
+            }
+            .onChange(of: timeSelection) { newValue in
+                draft.startTime = ScheduleEditorView.timeString(from: newValue)
+            }
+        }
+    }
+
+    private var detailsSection: some View {
+        Section("Details") {
+            TextField("Name", text: $draft.name)
+            DatePicker("Start Time",
+                       selection: $timeSelection,
+                       displayedComponents: .hourAndMinute)
+                .datePickerStyle(.compact)
+            Toggle("Enabled", isOn: $draft.isEnabled)
+        }
+    }
+
+    private var daysSection: some View {
+        Section("Days") {
+            ForEach(dayOptions, id: \.self) { day in
+                MultipleSelectionRow(title: day, isSelected: draft.days.contains(day)) {
+                    toggle(day: day)
                 }
             }
         }
+    }
+
+    private var sequenceSection: some View {
+        Section("Sequence") {
+            if draft.sequence.isEmpty {
+                Text("Add zones to control the watering order.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(Array(draft.sequence.enumerated()), id: \.element.id) { index, step in
+                    let binding = Binding(
+                        get: { draft.sequence[index] },
+                        set: { draft.sequence[index] = $0 }
+                    )
+                    ScheduleSequenceRow(step: binding,
+                                        pin: pinsByNumber[step.pin],
+                                        isPinEnabled: pinsByNumber[step.pin]?.isEnabled ?? true) {
+                        draft.removeSteps(at: IndexSet(integer: index))
+                    }
+                }
+                .onDelete { offsets in
+                    draft.removeSteps(at: offsets)
+                }
+                .onMove { offsets, newOffset in
+                    draft.moveSteps(from: offsets, to: newOffset)
+                }
+            }
+
+            if !missingActivePins.isEmpty {
+                Button {
+                    draft.addSteps(for: missingActivePins)
+                } label: {
+                    Label("Add All Active Pins", systemImage: "plus.circle.fill")
+                }
+
+                Menu {
+                    ForEach(missingActivePins) { pin in
+                        Button(pin.name ?? "Pin \(pin.pin)") {
+                            draft.addStep(for: pin)
+                        }
+                    }
+                } label: {
+                    Label("Add Pin", systemImage: "plus")
+                }
+            }
+
+            if !inactiveSteps.isEmpty {
+                Label("Inactive pins remain in this schedule", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .accessibilityHint("Enable the pin from the Zones screen to run it in this schedule")
+            }
+        }
+    }
+
+    private var isDraftSavable: Bool {
+        let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmedName.isEmpty && !draft.sequence.isEmpty
     }
 
     private func toggle(day: String) {
@@ -55,6 +153,28 @@ struct ScheduleEditorView: View {
         } else {
             draft.days.append(day)
         }
+    }
+
+    private static func date(from timeString: String) -> Date? {
+        let components = timeString.split(separator: ":")
+        guard components.count == 2,
+              let hour = Int(components[0]),
+              let minute = Int(components[1]) else { return nil }
+        return Calendar.current.date(bySettingHour: hour,
+                                     minute: minute,
+                                     second: 0,
+                                     of: Date())
+    }
+
+    private static func timeString(from date: Date) -> String {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        let hour = components.hour ?? 0
+        let minute = components.minute ?? 0
+        return String(format: "%02d:%02d", hour, minute)
+    }
+
+    private static var defaultTime: Date {
+        Calendar.current.date(bySettingHour: 6, minute: 0, second: 0, of: Date()) ?? Date()
     }
 }
 
@@ -75,5 +195,46 @@ private struct MultipleSelectionRow: View {
             }
         }
         .buttonStyle(.plain)
+    }
+}
+
+private struct ScheduleSequenceRow: View {
+    @Binding var step: ScheduleDraft.Step
+    let pin: PinDTO?
+    let isPinEnabled: Bool
+    let onDelete: () -> Void
+
+    private var pinName: String {
+        pin?.name ?? "Pin \(step.pin)"
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(pinName)
+                    .font(.body)
+                Text("GPIO \(step.pin)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                if !isPinEnabled {
+                    Label("Pin disabled", systemImage: "slash.circle")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            }
+            Spacer()
+            Stepper(value: $step.durationMinutes, in: 0...240) {
+                Text("\(step.durationMinutes) min")
+                    .font(.body.monospacedDigit())
+            }
+            .accessibilityLabel(Text("Duration for \(pinName)"))
+        }
+        .contentShape(Rectangle())
+        .opacity(isPinEnabled ? 1 : 0.5)
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive, action: onDelete) {
+                Label("Remove", systemImage: "trash")
+            }
+        }
     }
 }

--- a/SprinklerMobile/Views/ScheduleRowView.swift
+++ b/SprinklerMobile/Views/ScheduleRowView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ScheduleRowView: View {
+    @EnvironmentObject private var store: SprinklerStore
     let schedule: ScheduleDTO
 
     var body: some View {
@@ -8,8 +9,8 @@ struct ScheduleRowView: View {
             Text(schedule.name ?? "Schedule")
                 .font(.headline)
             HStack(spacing: 12) {
-                if let duration = schedule.durationMinutes {
-                    Label("\(duration) min", systemImage: "clock")
+                if let durationText = durationLabelText {
+                    Label(durationText, systemImage: "clock")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -24,8 +25,39 @@ struct ScheduleRowView: View {
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
+                if let sequenceText = sequenceSummaryText {
+                    Label(sequenceText, systemImage: "list.bullet")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
             }
         }
         .padding(.vertical, 6)
+    }
+
+    private var durationLabelText: String? {
+        let totalDuration = schedule.totalDuration(defaultPins: store.pins)
+        guard totalDuration > 0 else { return nil }
+        return "\(totalDuration) min"
+    }
+
+    private var sequenceSummaryText: String? {
+        let sequence = schedule.resolvedSequence(defaultPins: store.pins)
+        guard !sequence.isEmpty else { return nil }
+
+        let pinLookup = Dictionary(uniqueKeysWithValues: store.pins.map { ($0.pin, $0) })
+        let segments = sequence.map { item -> String in
+            let pinName = pinLookup[item.pin]?.name ?? "Pin \(item.pin)"
+            return "\(pinName) – \(item.durationMinutes)m"
+        }
+
+        if segments.count <= 3 {
+            return segments.joined(separator: ", ")
+        }
+
+        let prefix = segments.prefix(3).joined(separator: ", ")
+        return prefix + ", …"
     }
 }

--- a/SprinklerMobile/Views/SchedulesView.swift
+++ b/SprinklerMobile/Views/SchedulesView.swift
@@ -36,12 +36,20 @@ struct SchedulesView: View {
                     } else {
                         ForEach(store.schedules) { schedule in
                             Button {
-                                editingDraft = ScheduleDraft(schedule: schedule)
+                                editingDraft = ScheduleDraft(schedule: schedule, pins: store.pins)
                                 isPresentingEditor = true
                             } label: {
                                 ScheduleRowView(schedule: schedule)
                             }
                             .buttonStyle(.plain)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button {
+                                    store.duplicateSchedule(schedule)
+                                } label: {
+                                    Label("Duplicate", systemImage: "plus.square.on.square")
+                                }
+                                .tint(.accentColor)
+                            }
                         }
                         .onDelete { indexSet in
                             for index in indexSet {
@@ -106,7 +114,7 @@ struct SchedulesView: View {
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
-                        editingDraft = ScheduleDraft()
+                        editingDraft = ScheduleDraft(pins: store.pins)
                         isPresentingEditor = true
                     } label: {
                         Image(systemName: "plus")

--- a/SprinklerMobileTests/SprinklerStoreTests.swift
+++ b/SprinklerMobileTests/SprinklerStoreTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import Sprink
+
+@MainActor
+final class SprinklerStoreTests: XCTestCase {
+    func testSequenceScheduleTotalsAcrossMidnight() {
+        let store = makeStore()
+        let pins = [
+            PinDTO(pin: 4, name: "Front Lawn", isActive: nil, isEnabled: true),
+            PinDTO(pin: 5, name: "Back Lawn", isActive: nil, isEnabled: true)
+        ]
+        let schedule = ScheduleDTO(
+            id: "sequence-midnight",
+            name: "Overnight Soak",
+            startTime: "23:30",
+            days: ["Mon"],
+            isEnabled: true,
+            durationMinutes: nil,
+            sequence: [
+                ScheduleSequenceItemDTO(pin: 4, durationMinutes: 45),
+                ScheduleSequenceItemDTO(pin: 5, durationMinutes: 90)
+            ]
+        )
+
+        store.configureForTesting(pins: pins, schedules: [schedule])
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let reference = calendar.date(from: DateComponents(year: 2024, month: 5, day: 6, hour: 22))!
+
+        let runs = store.scheduleOccurrences(relativeTo: reference, calendar: calendar)
+        guard let run = runs.first(where: { $0.schedule.id == schedule.id }) else {
+            return XCTFail("Expected schedule run to be generated")
+        }
+
+        let expectedEnd = calendar.date(from: DateComponents(year: 2024, month: 5, day: 7, hour: 1, minute: 45))!
+        XCTAssertEqual(run.startDate, calendar.date(from: DateComponents(year: 2024, month: 5, day: 6, hour: 23, minute: 30)))
+        XCTAssertEqual(run.endDate, expectedEnd)
+    }
+
+    func testLegacyDurationExpandsToAllPins() {
+        let store = makeStore()
+        let pins = [
+            PinDTO(pin: 4, name: "Front Lawn", isActive: nil, isEnabled: true),
+            PinDTO(pin: 5, name: "Back Lawn", isActive: nil, isEnabled: true),
+            PinDTO(pin: 6, name: "Side Yard", isActive: nil, isEnabled: false)
+        ]
+        let legacySchedule = ScheduleDTO(
+            id: "legacy",
+            name: "Legacy",
+            startTime: "06:00",
+            days: ["Tue"],
+            isEnabled: true,
+            durationMinutes: 15,
+            sequence: nil
+        )
+
+        store.configureForTesting(pins: pins, schedules: [legacySchedule])
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let reference = calendar.date(from: DateComponents(year: 2024, month: 5, day: 7, hour: 5))!
+
+        let runs = store.scheduleOccurrences(relativeTo: reference, calendar: calendar)
+        guard let run = runs.first(where: { $0.schedule.id == legacySchedule.id }) else {
+            return XCTFail("Expected legacy schedule run to be generated")
+        }
+
+        let expectedEnd = calendar.date(from: DateComponents(year: 2024, month: 5, day: 7, hour: 6, minute: 30))!
+        XCTAssertEqual(run.startDate, calendar.date(from: DateComponents(year: 2024, month: 5, day: 7, hour: 6, minute: 0)))
+        XCTAssertEqual(run.endDate, expectedEnd)
+    }
+
+    private func makeStore() -> SprinklerStore {
+        let suiteName = "SprinklerStoreTests-\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return SprinklerStore(userDefaults: userDefaults,
+                              keychain: KeychainStub(),
+                              client: APIClient())
+    }
+}
+
+private final class KeychainStub: KeychainStoring {
+    private var storage: [String: String] = [:]
+
+    func string(forKey key: String) -> String? {
+        storage[key]
+    }
+
+    func set(_ value: String, forKey key: String) throws {
+        storage[key] = value
+    }
+
+    func deleteValue(forKey key: String) {
+        storage.removeValue(forKey: key)
+    }
+}


### PR DESCRIPTION
## Summary
- add sequence-aware schedule models and adapt the store’s timeline/duplicate handling
- refresh the schedule editor UI to edit per-pin durations with reordering, addition, and removal controls
- cover the sequence timeline logic with SprinklerStore unit tests for sequence and legacy schedules

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cda00d2b0483319e7af0ad8b8b8282