### PR TITLE
Improve keyboard dismissal across Sprinkler views

### DIFF
--- a/SprinklerMobile/Views/SettingsView.swift
+++ b/SprinklerMobile/Views/SettingsView.swift
@@ -50,6 +50,7 @@ struct SettingsView: View {
                     .padding(.horizontal, 20)
                     .padding(.vertical, 32)
                 }
+                .scrollDismissesKeyboard(.interactively)
             }
             .navigationTitle("Settings")
             .toolbar { keyboardToolbar }


### PR DESCRIPTION
## Summary
- add a focus state and dedicated keyboard toolbar to the zone duration list so the numeric keypad can be dismissed cleanly
- allow the dashboard and settings scroll views to dismiss the keyboard interactively when the user drags the content

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68cda57526608331bf4b4a7fe284f599