### PR TITLE
Fix ShapeStyle theme accessors and adopt new onChange API

### DIFF
--- a/SprinklerMobile/Utils/Color+Theme.swift
+++ b/SprinklerMobile/Utils/Color+Theme.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Provides ShapeStyle accessors for theme colour tokens so that `.foregroundStyle(.token)`
 /// and similar APIs compile across the codebase. The computed properties simply forward to
 /// the canonical definitions declared in `Theme.swift`.
-extension ShapeStyle where Self == Color {
+extension ShapeStyle {
     /// Primary canvas colour used for top-level backgrounds.
     static var appPrimaryBackground: Color { Color.appPrimaryBackground }
 

--- a/SprinklerMobile/Views/PinSettingsView.swift
+++ b/SprinklerMobile/Views/PinSettingsView.swift
@@ -46,8 +46,8 @@ struct PinSettingsView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { EditButton() }
         .onAppear { syncDrafts(force: true) }
-        .onChange(of: store.pins) { _ in syncDrafts(force: false) }
-        .onChange(of: focusedField) { newFocus in
+        .onChange(of: store.pins, initial: false) { _, _ in syncDrafts(force: false) }
+        .onChange(of: focusedField, initial: false) { _, newFocus in
             if let lastFocusedPin, lastFocusedPin != newFocus {
                 persistDraft(for: lastFocusedPin)
             }

--- a/SprinklerMobile/Views/ScheduleEditorView.swift
+++ b/SprinklerMobile/Views/ScheduleEditorView.swift
@@ -62,7 +62,7 @@ struct ScheduleEditorView: View {
                     }
                 }
             }
-            .onChange(of: timeSelection) { newValue in
+            .onChange(of: timeSelection, initial: false) { _, newValue in
                 draft.startTime = ScheduleEditorView.timeString(from: newValue)
             }
         }


### PR DESCRIPTION
## Summary
- expose theme colour helpers on all `ShapeStyle` conformers so `.foregroundStyle(.token)` builds again on iOS 18
- migrate remaining `onChange(of:perform:)` usages to the iOS 17+ API with explicit `initial` parameters

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cdb1df7b408331a3a82747d978972e