### PR TITLE
Update tint usage in SettingsView

### DIFF
--- a/SprinklerMobile/Views/SettingsView.swift
+++ b/SprinklerMobile/Views/SettingsView.swift
@@ -351,7 +351,7 @@ private struct PinManagementCard: View {
                 Spacer()
                 Image(systemName: "slider.horizontal.3")
                     .font(.title3)
-                    .foregroundStyle(.accentColor)
+                    .foregroundStyle(.tint)
                     .padding(12)
                     .background(Color.appSecondaryBackground.opacity(0.6))
                     .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
@@ -484,12 +484,12 @@ private struct RainDelaySettingsCard: View {
                 if !isZipValid {
                     Text("ZIP code must be five digits.")
                         .font(.caption)
-                        .foregroundStyle(.appDanger)
+                        .foregroundStyle(Color.appDanger)
                 }
                 if !isThresholdValid {
                     Text("Threshold must be between 0% and 100%.")
                         .font(.caption)
-                        .foregroundStyle(.appDanger)
+                        .foregroundStyle(Color.appDanger)
                 }
                 if !canEnableAutomation {
                     Text("Automation requires both a ZIP code and rain threshold.")


### PR DESCRIPTION
## Summary
- update settings view icon to use the environment tint color instead of the deprecated accent color style
- ensure danger text labels rely on Color.appDanger rather than the ShapeStyle extension

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdbbb28ff0833192c9badec5e74184