### PR TITLE
Update docs and API compat for sprinkler service

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,4 +2,4 @@ fastapi==0.111.0
 uvicorn[standard]==0.30.1
 pigpio==1.78
 python-dotenv==1.0.1
-pydantic==1.10.14
+pydantic>=2.7,<3


### PR DESCRIPTION
## Summary
- relax the backend pydantic dependency to support FastAPI 0.111
- add legacy-compatible /api routes that wrap the newer zone/status handlers
- refresh Raspberry Pi documentation to show the new endpoints, token usage, and standardize the systemd unit name
- align the README quick reference with the updated endpoints and service commands

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ce1de77de48331a0cc0b947801a4fa