### PR TITLE
Hardens controller URL normalization and health checks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,9 +50,12 @@ let package = Package(
                 "Models/ConnectionTestLog.swift",
                 "Models/DiscoveredDevice.swift",
                 "Data/APIError.swift",
-                "Services/HealthChecker.swift",
+                "Data/AuthenticationProtocols.swift",
+                "Services/HealthService.swift",
                 "Services/BonjourDiscoveryService.swift",
                 "Stores/ConnectivityStore.swift",
+                "Utils/ControllerConfig.swift",
+                "Utils/URLNormalize.swift",
                 "Utils/Validators.swift",
                 "ViewModels/DiscoveryViewModel.swift"
             ]

--- a/Sprink.xcodeproj/project.pbxproj
+++ b/Sprink.xcodeproj/project.pbxproj
@@ -9,16 +9,18 @@
 /* Begin PBXBuildFile section */
 		6208745A2E7D04D80062F269 /* BonjourDiscoveryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB8A2E7C7DCF001856FD /* BonjourDiscoveryServiceTests.swift */; };
 		6208745B2E7D04DD0062F269 /* ConnectivityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB8B2E7C7DCF001856FD /* ConnectivityStoreTests.swift */; };
-		6208745C2E7D04E30062F269 /* HealthCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB8C2E7C7DCF001856FD /* HealthCheckerTests.swift */; };
+                6208745C2E7D04E30062F269 /* HealthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB8C2E7C7DCF001856FD /* HealthServiceTests.swift */; };
 		6208747D2E7DF2C00062F269 /* Color+Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6208747C2E7DF2C00062F269 /* Color+Theme.swift */; };
 		621360F02E7C8AE30094E4D2 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 621360EF2E7C8AE30094E4D2 /* LaunchScreen.storyboard */; };
 		621360F32E7C8C730094E4D2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 621360F22E7C8C730094E4D2 /* Assets.xcassets */; };
 		6251FB8F2E7C7DCF001856FD /* RainDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB662E7C7DCF001856FD /* RainDTO.swift */; };
 		6251FB902E7C7DCF001856FD /* ConnectivityBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB7E2E7C7DCF001856FD /* ConnectivityBadgeView.swift */; };
-		6251FB912E7C7DCF001856FD /* SkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB782E7C7DCF001856FD /* SkeletonView.swift */; };
-		6251FB932E7C7DCF001856FD /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB642E7C7DCF001856FD /* HTTPClient.swift */; };
-		6251FB942E7C7DCF001856FD /* BonjourDiscoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB712E7C7DCF001856FD /* BonjourDiscoveryService.swift */; };
-		6251FB962E7C7DCF001856FD /* StatusDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB6B2E7C7DCF001856FD /* StatusDTO.swift */; };
+                6251FB912E7C7DCF001856FD /* SkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB782E7C7DCF001856FD /* SkeletonView.swift */; };
+                6251FB932E7C7DCF001856FD /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB642E7C7DCF001856FD /* HTTPClient.swift */; };
+                6251FB942E7C7DCF001856FD /* BonjourDiscoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB712E7C7DCF001856FD /* BonjourDiscoveryService.swift */; };
+                6BFEAF8D8CE34D24B3E6D573 /* ControllerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2866995A778497F91D3DDCE /* ControllerConfig.swift */; };
+                05C68F6C7FA04E5883B160B3 /* URLNormalize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4532F3E698CE4C0290A27EB5 /* URLNormalize.swift */; };
+                6251FB962E7C7DCF001856FD /* StatusDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB6B2E7C7DCF001856FD /* StatusDTO.swift */; };
 		6251FB972E7C7DCF001856FD /* KeychainStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB772E7C7DCF001856FD /* KeychainStorage.swift */; };
 		6251FB982E7C7DCF001856FD /* ConnectivityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB742E7C7DCF001856FD /* ConnectivityStore.swift */; };
 		6251FB992E7C7DCF001856FD /* PinsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB812E7C7DCF001856FD /* PinsListView.swift */; };
@@ -38,14 +40,15 @@
 		6251FBA82E7C7DCF001856FD /* ScheduleDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB682E7C7DCF001856FD /* ScheduleDTO.swift */; };
 		6251FBA92E7C7DCF001856FD /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB602E7C7DCF001856FD /* APIClient.swift */; };
 		6251FBAA2E7C7DCF001856FD /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB7F2E7C7DCF001856FD /* DashboardView.swift */; };
-		6251FBAC2E7C7DCF001856FD /* HealthChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB722E7C7DCF001856FD /* HealthChecker.swift */; };
+                6251FBAC2E7C7DCF001856FD /* HealthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB722E7C7DCF001856FD /* HealthService.swift */; };
 		6251FBAD2E7C7DCF001856FD /* PinDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB652E7C7DCF001856FD /* PinDTO.swift */; };
 		6251FBAE2E7C7DCF001856FD /* ScheduleGroupDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB692E7C7DCF001856FD /* ScheduleGroupDTO.swift */; };
 		6251FBAF2E7C7DCF001856FD /* DiscoveryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB7C2E7C7DCF001856FD /* DiscoveryViewModel.swift */; };
 		6251FBB02E7C7DCF001856FD /* ScheduleDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB672E7C7DCF001856FD /* ScheduleDraft.swift */; };
 		6251FBB12E7C7DCF001856FD /* RainStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB822E7C7DCF001856FD /* RainStatusView.swift */; };
 		6251FBB22E7C7DCF001856FD /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB612E7C7DCF001856FD /* APIError.swift */; };
-		6251FBB32E7C7DCF001856FD /* AuthenticationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FBB42E7C7DCF001856FD /* AuthenticationController.swift */; };
+                6251FBB32E7C7DCF001856FD /* AuthenticationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FBB42E7C7DCF001856FD /* AuthenticationController.swift */; };
+                30EFCF9138EE400195C87690 /* AuthenticationProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD706E816C6E4BE9A70C5903 /* AuthenticationProtocols.swift */; };
 		62D0AA012F0A1B2000000001 /* ConnectionTestLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D0AA002F0A1B2000000001 /* ConnectionTestLog.swift */; };
 		62D0AA032F0A1B2000000001 /* PinSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D0AA022F0A1B2000000001 /* PinSettingsView.swift */; };
 		AAA5C1E62E8D2F9000C533F1 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA5C1E52E8D2F9000C533F1 /* Theme.swift */; };
@@ -72,9 +75,10 @@
 		6251FB602E7C7DCF001856FD /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		6251FB612E7C7DCF001856FD /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		6251FB622E7C7DCF001856FD /* EmptyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyResponse.swift; sourceTree = "<group>"; };
-		6251FB632E7C7DCF001856FD /* GPIOCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPIOCatalog.swift; sourceTree = "<group>"; };
-		6251FB642E7C7DCF001856FD /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
-		6251FB652E7C7DCF001856FD /* PinDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinDTO.swift; sourceTree = "<group>"; };
+                6251FB632E7C7DCF001856FD /* GPIOCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPIOCatalog.swift; sourceTree = "<group>"; };
+                6251FB642E7C7DCF001856FD /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
+                FD706E816C6E4BE9A70C5903 /* AuthenticationProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationProtocols.swift; sourceTree = "<group>"; };
+                6251FB652E7C7DCF001856FD /* PinDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinDTO.swift; sourceTree = "<group>"; };
 		6251FB662E7C7DCF001856FD /* RainDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RainDTO.swift; sourceTree = "<group>"; };
 		6251FB672E7C7DCF001856FD /* ScheduleDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDraft.swift; sourceTree = "<group>"; };
 		6251FB682E7C7DCF001856FD /* ScheduleDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDTO.swift; sourceTree = "<group>"; };
@@ -84,13 +88,15 @@
 		6251FB6D2E7C7DCF001856FD /* DiscoveredDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredDevice.swift; sourceTree = "<group>"; };
 		6251FB6F2E7C7DCF001856FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6251FB712E7C7DCF001856FD /* BonjourDiscoveryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonjourDiscoveryService.swift; sourceTree = "<group>"; };
-		6251FB722E7C7DCF001856FD /* HealthChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthChecker.swift; sourceTree = "<group>"; };
+                6251FB722E7C7DCF001856FD /* HealthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthService.swift; sourceTree = "<group>"; };
 		6251FB742E7C7DCF001856FD /* ConnectivityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityStore.swift; sourceTree = "<group>"; };
 		6251FB752E7C7DCF001856FD /* SprinklerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SprinklerStore.swift; sourceTree = "<group>"; };
-		6251FB772E7C7DCF001856FD /* KeychainStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStorage.swift; sourceTree = "<group>"; };
-		6251FB782E7C7DCF001856FD /* SkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonView.swift; sourceTree = "<group>"; };
-		6251FB792E7C7DCF001856FD /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
-		6251FB7A2E7C7DCF001856FD /* Validators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Validators.swift; sourceTree = "<group>"; };
+                6251FB772E7C7DCF001856FD /* KeychainStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStorage.swift; sourceTree = "<group>"; };
+                6251FB782E7C7DCF001856FD /* SkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonView.swift; sourceTree = "<group>"; };
+                6251FB792E7C7DCF001856FD /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
+                B2866995A778497F91D3DDCE /* ControllerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControllerConfig.swift; sourceTree = "<group>"; };
+                4532F3E698CE4C0290A27EB5 /* URLNormalize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLNormalize.swift; sourceTree = "<group>"; };
+                6251FB7A2E7C7DCF001856FD /* Validators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Validators.swift; sourceTree = "<group>"; };
 		6251FB7C2E7C7DCF001856FD /* DiscoveryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryViewModel.swift; sourceTree = "<group>"; };
 		6251FB7E2E7C7DCF001856FD /* ConnectivityBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityBadgeView.swift; sourceTree = "<group>"; };
 		6251FB7F2E7C7DCF001856FD /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
@@ -104,7 +110,7 @@
 		6251FB882E7C7DCF001856FD /* SprinklerMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SprinklerMobileApp.swift; sourceTree = "<group>"; };
 		6251FB8A2E7C7DCF001856FD /* BonjourDiscoveryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonjourDiscoveryServiceTests.swift; sourceTree = "<group>"; };
 		6251FB8B2E7C7DCF001856FD /* ConnectivityStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityStoreTests.swift; sourceTree = "<group>"; };
-		6251FB8C2E7C7DCF001856FD /* HealthCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCheckerTests.swift; sourceTree = "<group>"; };
+                6251FB8C2E7C7DCF001856FD /* HealthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthServiceTests.swift; sourceTree = "<group>"; };
 		6251FBB42E7C7DCF001856FD /* AuthenticationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationController.swift; sourceTree = "<group>"; };
 		62D0AA002F0A1B2000000001 /* ConnectionTestLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionTestLog.swift; sourceTree = "<group>"; };
 		62D0AA022F0A1B2000000001 /* PinSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinSettingsView.swift; sourceTree = "<group>"; };
@@ -160,11 +166,12 @@
 		};
 		6251FB6C2E7C7DCF001856FD /* Data */ = {
 			isa = PBXGroup;
-			children = (
-				6251FBB42E7C7DCF001856FD /* AuthenticationController.swift */,
-				6251FB602E7C7DCF001856FD /* APIClient.swift */,
-				6251FB612E7C7DCF001856FD /* APIError.swift */,
-				6251FB622E7C7DCF001856FD /* EmptyResponse.swift */,
+                        children = (
+                                6251FBB42E7C7DCF001856FD /* AuthenticationController.swift */,
+                                FD706E816C6E4BE9A70C5903 /* AuthenticationProtocols.swift */,
+                                6251FB602E7C7DCF001856FD /* APIClient.swift */,
+                                6251FB612E7C7DCF001856FD /* APIError.swift */,
+                                6251FB622E7C7DCF001856FD /* EmptyResponse.swift */,
 				6251FB632E7C7DCF001856FD /* GPIOCatalog.swift */,
 				6251FB642E7C7DCF001856FD /* HTTPClient.swift */,
 				6251FB652E7C7DCF001856FD /* PinDTO.swift */,
@@ -201,7 +208,7 @@
 			isa = PBXGroup;
 			children = (
 				6251FB712E7C7DCF001856FD /* BonjourDiscoveryService.swift */,
-				6251FB722E7C7DCF001856FD /* HealthChecker.swift */,
+                            6251FB722E7C7DCF001856FD /* HealthService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -217,14 +224,16 @@
 		};
 		6251FB7B2E7C7DCF001856FD /* Utils */ = {
 			isa = PBXGroup;
-			children = (
-				6208747C2E7DF2C00062F269 /* Color+Theme.swift */,
-				AAA5C1E52E8D2F9000C533F1 /* Theme.swift */,
-				6251FB772E7C7DCF001856FD /* KeychainStorage.swift */,
-				6251FB782E7C7DCF001856FD /* SkeletonView.swift */,
-				6251FB792E7C7DCF001856FD /* Toast.swift */,
-				6251FB7A2E7C7DCF001856FD /* Validators.swift */,
-			);
+                        children = (
+                                6208747C2E7DF2C00062F269 /* Color+Theme.swift */,
+                                AAA5C1E52E8D2F9000C533F1 /* Theme.swift */,
+                                6251FB772E7C7DCF001856FD /* KeychainStorage.swift */,
+                                6251FB782E7C7DCF001856FD /* SkeletonView.swift */,
+                                6251FB792E7C7DCF001856FD /* Toast.swift */,
+                                B2866995A778497F91D3DDCE /* ControllerConfig.swift */,
+                                4532F3E698CE4C0290A27EB5 /* URLNormalize.swift */,
+                                6251FB7A2E7C7DCF001856FD /* Validators.swift */,
+                        );
 			path = Utils;
 			sourceTree = "<group>";
 		};
@@ -274,7 +283,7 @@
 			children = (
 				6251FB8A2E7C7DCF001856FD /* BonjourDiscoveryServiceTests.swift */,
 				6251FB8B2E7C7DCF001856FD /* ConnectivityStoreTests.swift */,
-				6251FB8C2E7C7DCF001856FD /* HealthCheckerTests.swift */,
+                            6251FB8C2E7C7DCF001856FD /* HealthServiceTests.swift */,
 			);
 			path = SprinklerConnectivityTests;
 			sourceTree = "<group>";
@@ -396,7 +405,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6208745A2E7D04D80062F269 /* BonjourDiscoveryServiceTests.swift in Sources */,
-				6208745C2E7D04E30062F269 /* HealthCheckerTests.swift in Sources */,
+                            6208745C2E7D04E30062F269 /* HealthServiceTests.swift in Sources */,
 				6208745B2E7D04DD0062F269 /* ConnectivityStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -416,8 +425,10 @@
 				6251FB982E7C7DCF001856FD /* ConnectivityStore.swift in Sources */,
 				62D0AA012F0A1B2000000001 /* ConnectionTestLog.swift in Sources */,
 				6251FB992E7C7DCF001856FD /* PinsListView.swift in Sources */,
-				6251FB9A2E7C7DCF001856FD /* Toast.swift in Sources */,
-				6251FB9B2E7C7DCF001856FD /* EmptyResponse.swift in Sources */,
+                                6251FB9A2E7C7DCF001856FD /* Toast.swift in Sources */,
+                                6BFEAF8D8CE34D24B3E6D573 /* ControllerConfig.swift in Sources */,
+                                05C68F6C7FA04E5883B160B3 /* URLNormalize.swift in Sources */,
+                                6251FB9B2E7C7DCF001856FD /* EmptyResponse.swift in Sources */,
 				6251FB9D2E7C7DCF001856FD /* PinRowView.swift in Sources */,
 				6251FB9E2E7C7DCF001856FD /* Validators.swift in Sources */,
 				6251FB9F2E7C7DCF001856FD /* SprinklerMobileApp.swift in Sources */,
@@ -434,15 +445,16 @@
 				6251FBA92E7C7DCF001856FD /* APIClient.swift in Sources */,
 				6251FBAA2E7C7DCF001856FD /* DashboardView.swift in Sources */,
 				AAA5C1E62E8D2F9000C533F1 /* Theme.swift in Sources */,
-				6251FBAC2E7C7DCF001856FD /* HealthChecker.swift in Sources */,
+                            6251FBAC2E7C7DCF001856FD /* HealthService.swift in Sources */,
 				6251FBAD2E7C7DCF001856FD /* PinDTO.swift in Sources */,
 				6251FBAE2E7C7DCF001856FD /* ScheduleGroupDTO.swift in Sources */,
 				6251FBAF2E7C7DCF001856FD /* DiscoveryViewModel.swift in Sources */,
 				6251FBB02E7C7DCF001856FD /* ScheduleDraft.swift in Sources */,
 				6251FBB12E7C7DCF001856FD /* RainStatusView.swift in Sources */,
-				6251FBB22E7C7DCF001856FD /* APIError.swift in Sources */,
-				6251FBB32E7C7DCF001856FD /* AuthenticationController.swift in Sources */,
-			);
+                                6251FBB22E7C7DCF001856FD /* APIError.swift in Sources */,
+                                6251FBB32E7C7DCF001856FD /* AuthenticationController.swift in Sources */,
+                                30EFCF9138EE400195C87690 /* AuthenticationProtocols.swift in Sources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */

--- a/SprinklerMobile/Data/AuthenticationController.swift
+++ b/SprinklerMobile/Data/AuthenticationController.swift
@@ -1,26 +1,5 @@
 import Foundation
 
-/// Protocol describing a type that can vend authentication headers for outbound requests.
-///
-/// This lets the networking stack remain decoupled from how credentials are stored while
-/// still allowing the HTTP client to attach security metadata when needed.
-protocol AuthenticationProviding: AnyObject {
-    /// Returns the HTTP header field/value pair that should be attached to the request.
-    /// - Returns: A tuple describing the header key and value or `nil` when no credentials are available.
-    func authorizationHeader() async -> (key: String, value: String)?
-}
-
-/// Extends ``AuthenticationProviding`` with mutation capabilities so the application can
-/// update credentials as the user supplies new tokens.
-protocol AuthenticationManaging: AuthenticationProviding {
-    /// Persists the supplied token securely for future requests.
-    /// - Parameter token: The raw authentication token or `nil` to remove the current credential.
-    func updateToken(_ token: String?) async throws
-
-    /// Retrieves the currently stored token so callers can reflect it in UI or analytics if needed.
-    func currentToken() async -> String?
-}
-
 /// Actor responsible for securely persisting and vendoring the authorization token used by the sprinkler API.
 ///
 /// The token is stored in the keychain so it survives application launches without being exposed in user defaults

--- a/SprinklerMobile/Data/AuthenticationProtocols.swift
+++ b/SprinklerMobile/Data/AuthenticationProtocols.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Protocol describing a type that can vend authentication headers for outbound requests.
+///
+/// This lets the networking stack remain decoupled from how credentials are stored while
+/// still allowing the HTTP client to attach security metadata when needed.
+public protocol AuthenticationProviding: AnyObject {
+    /// Returns the HTTP header field/value pair that should be attached to the request.
+    /// - Returns: A tuple describing the header key and value or `nil` when no credentials are available.
+    func authorizationHeader() async -> (key: String, value: String)?
+}
+
+/// Extends ``AuthenticationProviding`` with mutation capabilities so the application can
+/// update credentials as the user supplies new tokens.
+public protocol AuthenticationManaging: AuthenticationProviding {
+    /// Persists the supplied token securely for future requests.
+    /// - Parameter token: The raw authentication token or `nil` to remove the current credential.
+    func updateToken(_ token: String?) async throws
+
+    /// Retrieves the currently stored token so callers can reflect it in UI or analytics if needed.
+    func currentToken() async -> String?
+}

--- a/SprinklerMobile/Models/DiscoveredDevice.swift
+++ b/SprinklerMobile/Models/DiscoveredDevice.swift
@@ -15,7 +15,15 @@ struct DiscoveredDevice: Identifiable, Equatable {
 
     /// Builds a usable base URL string for making requests to the controller.
     var baseURLString: String {
-        if let h = host { return "http://\(h):\(port)" }
+        if let h = host {
+            let sanitized = URLNormalize.sanitizedHost(h)
+            if !sanitized.isEmpty {
+                if sanitized.contains(":") {
+                    return "http://[\(sanitized)]:\(port)"
+                }
+                return "http://\(sanitized):\(port)"
+            }
+        }
         if let ip = ip {
             return ip.contains(":") ? "http://[\(ip)]:\(port)" : "http://\(ip):\(port)"
         }

--- a/SprinklerMobile/Services/BonjourDiscoveryService.swift
+++ b/SprinklerMobile/Services/BonjourDiscoveryService.swift
@@ -127,7 +127,11 @@ final class BonjourDiscoveryService: NSObject, BonjourDiscoveryProviding {
     private static func makeDevice(from service: NetService) -> DiscoveredDevice? {
         guard service.port > 0 else { return nil }
         let trimmedHost = service.hostName?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let host = trimmedHost?.isEmpty == false ? trimmedHost : nil
+        let host = trimmedHost
+            .flatMap { value -> String? in
+                let sanitized = URLNormalize.sanitizedHost(value)
+                return sanitized.isEmpty ? nil : sanitized
+            }
         let ip = Self.extractIPAddress(from: service.addresses)
 
         guard let identifierSource = host ?? ip else { return nil }

--- a/SprinklerMobile/SprinklerMobileApp.swift
+++ b/SprinklerMobile/SprinklerMobileApp.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 @main
 struct SprinklerMobileApp: App {
-    @StateObject private var connectivityStore = ConnectivityStore()
+    @StateObject private var connectivityStore = ConnectivityStore(
+        checker: HealthService(authentication: AuthenticationController())
+    )
     @StateObject private var sprinklerStore = SprinklerStore()
 
     var body: some Scene {

--- a/SprinklerMobile/Utils/ControllerConfig.swift
+++ b/SprinklerMobile/Utils/ControllerConfig.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Centralizes constants that describe the default sprinkler controller configuration.
+///
+/// Having a dedicated type keeps the default address in sync across the connectivity
+/// store, placeholder UI strings, and any other code that needs to know the
+/// controller's canonical base URL.
+enum ControllerConfig {
+    /// Default scheme used when the user does not explicitly enter one.
+    static let defaultScheme = "http"
+
+    /// Default Bonjour host name advertised by the sprinkler controller.
+    static let defaultHost = "sprinkler.local"
+
+    /// Default TCP port exposed by the controller web service.
+    static let defaultPort = 5000
+
+    /// Canonical base URL used for new installations before the user customises the address.
+    static var defaultBaseURL: URL {
+        var components = URLComponents()
+        components.scheme = defaultScheme
+        components.host = defaultHost
+        components.port = defaultPort
+        components.path = ""
+        // The above configuration is guaranteed to produce a valid URL because
+        // we provide the required pieces (scheme + host). Force unwrap keeps the
+        // call sites tidy while still crashing in development if something ever
+        // becomes inconsistent in the future.
+        return components.url!
+    }
+
+    /// String representation of the canonical base URL used by default in the UI.
+    static var defaultBaseAddress: String { defaultBaseURL.absoluteString }
+}

--- a/SprinklerMobile/Utils/URLNormalize.swift
+++ b/SprinklerMobile/Utils/URLNormalize.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Collection of helpers that normalise user-supplied or discovered controller URLs.
+///
+/// These utilities strip Bonjour artefacts such as trailing dots, ensure hosts are
+/// consistently lowercased, and return canonical URLs that can be safely persisted
+/// or displayed to the user.
+enum URLNormalize {
+    /// Removes whitespace, trailing dots and uppercasing from the supplied host name.
+    /// - Parameter host: Raw host string extracted from user input or Bonjour discovery.
+    /// - Returns: A cleaned up host value suitable for use in URLComponents.
+    static func sanitizedHost(_ host: String) -> String {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return trimmed }
+
+        var sanitized = trimmed
+        while sanitized.last == "." {
+            sanitized.removeLast()
+        }
+
+        return sanitized.lowercased()
+    }
+
+    /// Produces a canonical URL by cleaning up the host and removing redundant trailing slashes.
+    /// - Parameter url: The original URL.
+    /// - Returns: A URL with a sanitized host and no single trailing slash path.
+    static func normalized(_ url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url
+        }
+
+        if let host = components.host, !host.isEmpty {
+            let cleaned = sanitizedHost(host)
+            if !cleaned.isEmpty {
+                components.host = cleaned
+            }
+        }
+
+        if components.percentEncodedPath == "/" {
+            components.percentEncodedPath = ""
+        }
+
+        return components.url ?? url
+    }
+}

--- a/SprinklerMobile/Utils/Validators.swift
+++ b/SprinklerMobile/Utils/Validators.swift
@@ -37,7 +37,11 @@ enum Validators {
         }
 
         if let host = components.host?.trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty {
-            components.host = host.lowercased()
+            let sanitized = URLNormalize.sanitizedHost(host)
+            guard !sanitized.isEmpty else {
+                throw APIError.validationFailed("Please include the host or IP address.")
+            }
+            components.host = sanitized
         }
 
         guard let host = components.host, !host.isEmpty else {

--- a/SprinklerMobile/Views/SettingsView.swift
+++ b/SprinklerMobile/Views/SettingsView.swift
@@ -244,7 +244,7 @@ private struct ConnectionSettingsCard: CardView {
             }
 
             VStack(spacing: 12) {
-                TextField("http://sprinkler.local:8000", text: $baseURL)
+                TextField(ControllerConfig.defaultBaseAddress, text: $baseURL)
                     .textInputAutocapitalization(.never)
                     .keyboardType(.URL)
                     .disableAutocorrection(true)

--- a/Tests/SprinklerConnectivityTests/BonjourDiscoveryServiceTests.swift
+++ b/Tests/SprinklerConnectivityTests/BonjourDiscoveryServiceTests.swift
@@ -8,13 +8,18 @@ import XCTest
 
 final class BonjourDiscoveryServiceTests: XCTestCase {
     func testBaseURLPrefersHost() {
-        let device = DiscoveredDevice(id: "sprinkler.local:8000", name: "sprinkler", host: "sprinkler.local", ip: "192.168.1.10", port: 8000)
-        XCTAssertEqual(device.baseURLString, "http://sprinkler.local:8000")
+        let device = DiscoveredDevice(id: "sprinkler.local:5000", name: "sprinkler", host: "sprinkler.local", ip: "192.168.1.10", port: 5000)
+        XCTAssertEqual(device.baseURLString, "http://sprinkler.local:5000")
     }
 
     func testBaseURLFallsBackToIPv6() {
         let device = DiscoveredDevice(id: "[fd00::1]:8000", name: "sprinkler", host: nil, ip: "fd00::1", port: 8000)
         XCTAssertEqual(device.baseURLString, "http://[fd00::1]:8000")
+    }
+
+    func testBaseURLStripsTrailingDotFromHost() {
+        let device = DiscoveredDevice(id: "sprinkler.local.:5000", name: "sprinkler", host: "sprinkler.local.", ip: nil, port: 5000)
+        XCTAssertEqual(device.baseURLString, "http://sprinkler.local:5000")
     }
 }
 #endif

--- a/Tests/SprinklerConnectivityTests/ConnectivityStoreTests.swift
+++ b/Tests/SprinklerConnectivityTests/ConnectivityStoreTests.swift
@@ -34,6 +34,12 @@ final class ConnectivityStoreTests: XCTestCase {
         XCTAssertEqual(url?.absoluteString, "http://sprinkler.local:1234")
     }
 
+    @MainActor
+    func testNormalizedBaseURLStripsTrailingDot() {
+        let url = ConnectivityStore.normalizedBaseURL(from: "http://sprinkler.local.:5000")
+        XCTAssertEqual(url?.absoluteString, "http://sprinkler.local:5000")
+    }
+
     func testConcurrentCallsDoNotTriggerMultipleChecks() async {
         let suiteName = "sprinkler.connectivity.concurrent"
         guard let defaults = UserDefaults(suiteName: suiteName) else {


### PR DESCRIPTION
## Summary
- centralize controller configuration defaults and shared authentication protocols
- add a token-aware HealthService with status endpoint fallbacks and improved URL normalization
- refresh discovery, settings UI, and tests to cover the new normalization behavior

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ce3c0922988331a8578cfd2e4925e1