### PR TITLE
Revert asset catalog to vector resources

### DIFF
--- a/SprinklerMobile/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SprinklerMobile/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,46 +1,67 @@
 {
   "images": [
     {
+      "filename": "AppIcon.pdf",
       "idiom": "iphone",
       "scale": "2x",
       "size": "20x20"
     },
     {
+      "filename": "AppIcon.pdf",
       "idiom": "iphone",
       "scale": "3x",
       "size": "20x20"
     },
     {
+      "filename": "AppIcon.pdf",
       "idiom": "iphone",
       "scale": "2x",
       "size": "29x29"
     },
     {
+      "filename": "AppIcon.pdf",
       "idiom": "iphone",
       "scale": "3x",
       "size": "29x29"
     },
     {
+      "filename": "AppIcon.pdf",
       "idiom": "iphone",
       "scale": "2x",
       "size": "40x40"
     },
     {
+      "filename": "AppIcon.pdf",
       "idiom": "iphone",
       "scale": "3x",
       "size": "40x40"
     },
     {
+      "filename": "AppIcon.pdf",
       "idiom": "iphone",
       "scale": "2x",
       "size": "60x60"
     },
     {
+      "filename": "AppIcon.pdf",
       "idiom": "iphone",
       "scale": "3x",
       "size": "60x60"
     },
     {
+      "filename": "AppIcon.pdf",
+      "idiom": "ipad",
+      "scale": "2x",
+      "size": "76x76"
+    },
+    {
+      "filename": "AppIcon.pdf",
+      "idiom": "ipad",
+      "scale": "2x",
+      "size": "83.5x83.5"
+    },
+    {
+      "filename": "AppIcon.pdf",
       "idiom": "ios-marketing",
       "scale": "1x",
       "size": "1024x1024"
@@ -49,5 +70,8 @@
   "info": {
     "author": "xcode",
     "version": 1
+  },
+  "properties": {
+    "preserves-vector-representation": true
   }
 }


### PR DESCRIPTION
## Summary
- remove the previously added PNG icon and accent assets to eliminate binary files from the repository
- restore the AccentColor asset as a standard SRGB colorset definition
- update the app icon catalog to reference a single vector PDF while preserving vector rendering properties

## Testing
- Not run (asset-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cec55fd95c83318e366fe4bb102df3