### PR TITLE
Add Bonjour discovery state publishers for settings

### DIFF
--- a/SprinklerMobile/ViewModels/DiscoveryViewModel.swift
+++ b/SprinklerMobile/ViewModels/DiscoveryViewModel.swift
@@ -26,18 +26,30 @@ final class DiscoveryViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.devices = $0 }
             .store(in: &cancellables)
+
+        service.isBrowsingPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.isBrowsing = $0 }
+            .store(in: &cancellables)
+
+        service.errorPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.errorMessage = $0 }
+            .store(in: &cancellables)
         #endif
     }
 
     /// Starts discovery and flips the browsing flag.
     func start() {
         isBrowsing = true
+        errorMessage = nil
         service.start()
     }
 
     /// Forces a new discovery pass by calling refresh on the service.
     func refresh() {
         isBrowsing = true
+        errorMessage = nil
         service.refresh()
     }
 


### PR DESCRIPTION
## Summary
- expand the Bonjour discovery service with browsing and error publishers so SwiftUI can react to activity
- subscribe the settings discovery view model to the new publishers and clear stale errors when restarting discovery

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cecc5d94948331b13a91b6349aaf4c