### PR TITLE
Add dashboard connectivity status badge

### DIFF
--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -35,6 +35,7 @@ struct DashboardView: View {
 
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 24) {
+                        connectivityStatusBadge
                         ledStatusCard
                         DashboardCard(title: "Schedule Summary") {
                             ScheduleSummaryView()
@@ -60,6 +61,13 @@ struct DashboardView: View {
         }
         .environment(\.editMode, $pinListEditMode)
         .toast(state: toastBinding)
+    }
+
+    /// High level controller connectivity indicator shown at the top of the dashboard.
+    private var connectivityStatusBadge: some View {
+        ConnectivityBadgeView(state: connectivityStore.state,
+                               isLoading: connectivityStore.isChecking || sprinklerStore.isRefreshing)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     /// Section containing a compact grid of GPIO indicators along with controller and rain status lights.


### PR DESCRIPTION
## Summary
- add the connectivity status badge to the dashboard so controller health is always visible
- show the badge loader while either connectivity or sprinkler data is refreshing

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cecdb8fcc88331969cab18a40a130f