### PR TITLE
Add offline schedule persistence and sync

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,8 @@ let package = Package(
                 "Data/PinDTO.swift",
                 "Data/SSLPinningDelegate.swift",
                 "Data/ScheduleDraft.swift",
+                "Data/Schedule.swift",
+                "Data/SchedulePersistence.swift",
                 "Data/GPIOCatalog.swift",
                 "Utils/KeychainStorage.swift",
                 "Utils/SkeletonView.swift",

--- a/Sprink.xcodeproj/project.pbxproj
+++ b/Sprink.xcodeproj/project.pbxproj
@@ -37,9 +37,11 @@
 		6251FBA42E7C7DCF001856FD /* DiscoveredDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB6D2E7C7DCF001856FD /* DiscoveredDevice.swift */; };
 		6251FBA52E7C7DCF001856FD /* SchedulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB852E7C7DCF001856FD /* SchedulesView.swift */; };
 		6251FBA62E7C7DCF001856FD /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB862E7C7DCF001856FD /* SettingsView.swift */; };
-		6251FBA72E7C7DCF001856FD /* GPIOCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB632E7C7DCF001856FD /* GPIOCatalog.swift */; };
-		6251FBA82E7C7DCF001856FD /* ScheduleDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB682E7C7DCF001856FD /* ScheduleDTO.swift */; };
-		6251FBA92E7C7DCF001856FD /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB602E7C7DCF001856FD /* APIClient.swift */; };
+                6251FBA72E7C7DCF001856FD /* GPIOCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB632E7C7DCF001856FD /* GPIOCatalog.swift */; };
+                6251FBA82E7C7DCF001856FD /* ScheduleDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB682E7C7DCF001856FD /* ScheduleDTO.swift */; };
+                62E0B1A12F4D9C0B00A1B2C0 /* Schedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E0B1A02F4D9C0B00A1B2C0 /* Schedule.swift */; };
+                62E0B1A32F4D9C0B00A1B2C0 /* SchedulePersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E0B1A22F4D9C0B00A1B2C0 /* SchedulePersistence.swift */; };
+                6251FBA92E7C7DCF001856FD /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB602E7C7DCF001856FD /* APIClient.swift */; };
 		6251FBAA2E7C7DCF001856FD /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB7F2E7C7DCF001856FD /* DashboardView.swift */; };
                 6251FBAC2E7C7DCF001856FD /* HealthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB722E7C7DCF001856FD /* HealthService.swift */; };
 		6251FBAD2E7C7DCF001856FD /* PinDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB652E7C7DCF001856FD /* PinDTO.swift */; };
@@ -80,9 +82,11 @@
                 FD706E816C6E4BE9A70C5903 /* AuthenticationProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationProtocols.swift; sourceTree = "<group>"; };
                 6251FB652E7C7DCF001856FD /* PinDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinDTO.swift; sourceTree = "<group>"; };
 		6251FB662E7C7DCF001856FD /* RainDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RainDTO.swift; sourceTree = "<group>"; };
-		6251FB672E7C7DCF001856FD /* ScheduleDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDraft.swift; sourceTree = "<group>"; };
-		6251FB682E7C7DCF001856FD /* ScheduleDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDTO.swift; sourceTree = "<group>"; };
-		6251FB6A2E7C7DCF001856FD /* SSLPinningDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLPinningDelegate.swift; sourceTree = "<group>"; };
+                6251FB672E7C7DCF001856FD /* ScheduleDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDraft.swift; sourceTree = "<group>"; };
+                6251FB682E7C7DCF001856FD /* ScheduleDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDTO.swift; sourceTree = "<group>"; };
+                62E0B1A02F4D9C0B00A1B2C0 /* Schedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schedule.swift; sourceTree = "<group>"; };
+                62E0B1A22F4D9C0B00A1B2C0 /* SchedulePersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulePersistence.swift; sourceTree = "<group>"; };
+                6251FB6A2E7C7DCF001856FD /* SSLPinningDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLPinningDelegate.swift; sourceTree = "<group>"; };
 		6251FB6B2E7C7DCF001856FD /* StatusDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusDTO.swift; sourceTree = "<group>"; };
 		6251FB6D2E7C7DCF001856FD /* DiscoveredDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredDevice.swift; sourceTree = "<group>"; };
 		6251FB6F2E7C7DCF001856FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -166,9 +170,11 @@
 				6251FB632E7C7DCF001856FD /* GPIOCatalog.swift */,
 				6251FB642E7C7DCF001856FD /* HTTPClient.swift */,
 				6251FB652E7C7DCF001856FD /* PinDTO.swift */,
-				6251FB662E7C7DCF001856FD /* RainDTO.swift */,
-				6251FB672E7C7DCF001856FD /* ScheduleDraft.swift */,
+                                6251FB662E7C7DCF001856FD /* RainDTO.swift */,
+                                6251FB672E7C7DCF001856FD /* ScheduleDraft.swift */,
                                 6251FB682E7C7DCF001856FD /* ScheduleDTO.swift */,
+                                62E0B1A02F4D9C0B00A1B2C0 /* Schedule.swift */,
+                                62E0B1A22F4D9C0B00A1B2C0 /* SchedulePersistence.swift */,
                                 6251FB6A2E7C7DCF001856FD /* SSLPinningDelegate.swift */,
 				6251FB6B2E7C7DCF001856FD /* StatusDTO.swift */,
 			);
@@ -429,9 +435,11 @@
 				6251FBA52E7C7DCF001856FD /* SchedulesView.swift in Sources */,
 				6251FBA62E7C7DCF001856FD /* SettingsView.swift in Sources */,
 				62D0AA032F0A1B2000000001 /* PinSettingsView.swift in Sources */,
-				6251FBA72E7C7DCF001856FD /* GPIOCatalog.swift in Sources */,
-				6251FBA82E7C7DCF001856FD /* ScheduleDTO.swift in Sources */,
-				6251FBA92E7C7DCF001856FD /* APIClient.swift in Sources */,
+                                6251FBA72E7C7DCF001856FD /* GPIOCatalog.swift in Sources */,
+                                6251FBA82E7C7DCF001856FD /* ScheduleDTO.swift in Sources */,
+                                62E0B1A12F4D9C0B00A1B2C0 /* Schedule.swift in Sources */,
+                                62E0B1A32F4D9C0B00A1B2C0 /* SchedulePersistence.swift in Sources */,
+                                6251FBA92E7C7DCF001856FD /* APIClient.swift in Sources */,
 				6251FBAA2E7C7DCF001856FD /* DashboardView.swift in Sources */,
 				AAA5C1E62E8D2F9000C533F1 /* Theme.swift in Sources */,
                             6251FBAC2E7C7DCF001856FD /* HealthService.swift in Sources */,

--- a/SprinklerMobile/Data/Schedule.swift
+++ b/SprinklerMobile/Data/Schedule.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Domain representation of a watering schedule that can be persisted locally and
+/// synchronised with the Raspberry Pi controller when network connectivity is
+/// available. The struct purposefully mirrors the controller payload so the same
+/// value can be encoded to JSON for offline storage or REST payloads.
+struct Schedule: Identifiable, Codable, Hashable {
+    /// Describes a single step in a watering sequence.
+    struct Step: Codable, Hashable {
+        var pin: Int
+        var durationMinutes: Int
+    }
+
+    var id: String
+    var name: String
+    var startTime: String
+    var days: [String]
+    var isEnabled: Bool
+    var sequence: [Step]
+    /// Last time the schedule was modified locally.
+    var lastModified: Date
+    /// Timestamp of the last successful controller sync. `nil` means the
+    /// schedule has never been uploaded to the controller.
+    var lastSyncedAt: Date?
+
+    init(id: String = UUID().uuidString,
+         name: String = "",
+         startTime: String = Schedule.defaultStartTime,
+         days: [String] = Schedule.defaultDays,
+         isEnabled: Bool = true,
+         sequence: [Step] = [],
+         lastModified: Date = Date(),
+         lastSyncedAt: Date? = nil) {
+        self.id = id
+        self.name = name
+        self.startTime = startTime
+        self.days = Schedule.orderedDays(from: days)
+        self.isEnabled = isEnabled
+        self.sequence = sequence
+        self.lastModified = lastModified
+        self.lastSyncedAt = lastSyncedAt
+    }
+
+    /// Returns the total runtime for the schedule by summing every sequence step.
+    var totalDurationMinutes: Int {
+        sequence.reduce(into: 0) { partialResult, step in
+            partialResult += max(step.durationMinutes, 0)
+        }
+    }
+
+    /// Indicates whether local changes still need to be synchronised to the controller.
+    var needsSync: Bool {
+        guard let lastSyncedAt else { return true }
+        return lastSyncedAt < lastModified
+    }
+
+    /// Provides an ordered representation of weekdays that matches the UI and backend expectations.
+    static func orderedDays(from days: [String]) -> [String] {
+        let lowercased = Set(days.map { $0.lowercased() })
+        return defaultDays.filter { lowercased.contains($0.lowercased()) }
+    }
+
+    /// Sanitises the name to ensure we never persist schedules with whitespace-only titles.
+    var sanitizedName: String? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Returns a write payload compatible with the existing controller API.
+    func writePayload() -> ScheduleWritePayload {
+        let normalisedSequence = sequence.map { step in
+            ScheduleWritePayload.Step(pin: step.pin,
+                                       durationMinutes: max(step.durationMinutes, 0))
+        }
+        let fallbackDuration = normalisedSequence.first?.durationMinutes ?? Schedule.defaultDurationMinutes
+        return ScheduleWritePayload(name: sanitizedName,
+                                    durationMinutes: fallbackDuration,
+                                    startTime: startTime,
+                                    days: days.isEmpty ? nil : Schedule.orderedDays(from: days),
+                                    isEnabled: isEnabled,
+                                    sequence: normalisedSequence)
+    }
+}
+
+extension Schedule {
+    static let defaultStartTime = "06:00"
+    static let defaultDurationMinutes = 10
+    static let defaultDays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+}
+
+extension Schedule {
+    /// Creates a persisted schedule from the controller DTO. Any controller-provided
+    /// data is considered authoritative, so both `lastModified` and `lastSyncedAt`
+    /// are stamped with the time of decoding.
+    init(dto: ScheduleDTO, defaultPins: [PinDTO]) {
+        let resolvedSequence = dto.resolvedSequence(defaultPins: defaultPins)
+        let now = Date()
+        self.init(id: dto.id,
+                  name: dto.name ?? "",
+                  startTime: dto.startTime ?? Schedule.defaultStartTime,
+                  days: dto.days ?? Schedule.defaultDays,
+                  isEnabled: dto.isEnabled ?? true,
+                  sequence: resolvedSequence.map { Step(pin: $0.pin, durationMinutes: $0.durationMinutes) },
+                  lastModified: now,
+                  lastSyncedAt: now)
+    }
+
+    /// Converts the persisted representation back into a DTO for use with
+    /// components that still rely on the legacy type.
+    func dto() -> ScheduleDTO {
+        ScheduleDTO(id: id,
+                    name: sanitizedName,
+                    startTime: startTime,
+                    days: days,
+                    isEnabled: isEnabled,
+                    durationMinutes: sequence.first?.durationMinutes,
+                    sequence: sequence.map { step in
+                        ScheduleSequenceItemDTO(pin: step.pin, durationMinutes: step.durationMinutes)
+                    })
+    }
+}
+

--- a/SprinklerMobile/Data/ScheduleDraft.swift
+++ b/SprinklerMobile/Data/ScheduleDraft.swift
@@ -22,41 +22,40 @@ struct ScheduleDraft: Identifiable, Equatable {
 
     init(id: String = UUID().uuidString,
          name: String = "",
-         startTime: String = "06:00",
-         days: [String] = ScheduleDraft.defaultDays,
+         startTime: String = Schedule.defaultStartTime,
+         days: [String] = Schedule.defaultDays,
          isEnabled: Bool = true,
          sequence: [Step] = [],
          pins: [PinDTO] = []) {
         self.id = id
         self.name = name
         self.startTime = startTime
-        self.days = ScheduleDraft.orderedDays(from: days)
+        self.days = Schedule.orderedDays(from: days)
         self.isEnabled = isEnabled
         if sequence.isEmpty {
             let resolvedPins = pins.filter { $0.isEnabled ?? true }
             let seeds = resolvedPins.isEmpty ? pins : resolvedPins
-            self.sequence = seeds.map { Step(pin: $0.pin, durationMinutes: Self.defaultDurationMinutes) }
+            self.sequence = seeds.map { Step(pin: $0.pin, durationMinutes: Schedule.defaultDurationMinutes) }
         } else {
             self.sequence = sequence
         }
     }
 
-    init(schedule: ScheduleDTO, pins: [PinDTO] = []) {
+    init(schedule: Schedule, pins: [PinDTO] = []) {
         self.id = schedule.id
-        self.name = schedule.name ?? ""
-        self.startTime = schedule.startTime ?? "06:00"
-        if let specifiedDays = schedule.days, !specifiedDays.isEmpty {
-            self.days = ScheduleDraft.orderedDays(from: specifiedDays)
+        self.name = schedule.name
+        self.startTime = schedule.startTime
+        if schedule.days.isEmpty {
+            self.days = Schedule.defaultDays
         } else {
-            self.days = ScheduleDraft.defaultDays
+            self.days = Schedule.orderedDays(from: schedule.days)
         }
-        self.isEnabled = schedule.isEnabled ?? true
-        let resolvedSequence = schedule.resolvedSequence(defaultPins: pins)
-        if resolvedSequence.isEmpty, let firstPin = pins.first {
+        self.isEnabled = schedule.isEnabled
+        if schedule.sequence.isEmpty, let firstPin = pins.first {
             self.sequence = [Step(pin: firstPin.pin,
-                                   durationMinutes: schedule.durationMinutes ?? Self.defaultDurationMinutes)]
+                                   durationMinutes: Schedule.defaultDurationMinutes)]
         } else {
-            self.sequence = resolvedSequence.map { item in
+            self.sequence = schedule.sequence.map { item in
                 Step(pin: item.pin, durationMinutes: item.durationMinutes)
             }
         }
@@ -69,11 +68,11 @@ struct ScheduleDraft: Identifiable, Equatable {
             copy.durationMinutes = max(copy.durationMinutes, 0)
             return copy
         }
-        let fallbackDuration = sanitizedSequence.first?.durationMinutes ?? Self.defaultDurationMinutes
+        let fallbackDuration = sanitizedSequence.first?.durationMinutes ?? Schedule.defaultDurationMinutes
         return ScheduleWritePayload(name: trimmedName.isEmpty ? nil : trimmedName,
                                     durationMinutes: fallbackDuration,
                                     startTime: startTime,
-                                    days: days.isEmpty ? nil : ScheduleDraft.orderedDays(from: days),
+                                    days: days.isEmpty ? nil : Schedule.orderedDays(from: days),
                                     isEnabled: isEnabled,
                                     sequence: sanitizedSequence.map { step in
                                         ScheduleWritePayload.Step(pin: step.pin,
@@ -81,9 +80,23 @@ struct ScheduleDraft: Identifiable, Equatable {
                                     })
     }
 
+    var schedule: Schedule {
+        let sanitizedSequence = sequence.map { step in
+            Schedule.Step(pin: step.pin, durationMinutes: max(step.durationMinutes, 0))
+        }
+        return Schedule(id: id,
+                         name: name,
+                         startTime: startTime,
+                         days: days,
+                         isEnabled: isEnabled,
+                         sequence: sanitizedSequence,
+                         lastModified: Date(),
+                         lastSyncedAt: nil)
+    }
+
     mutating func addSteps(for pins: [PinDTO]) {
         let existingPins = Set(sequence.map(\.pin))
-        let defaultDuration = sequence.first?.durationMinutes ?? Self.defaultDurationMinutes
+        let defaultDuration = sequence.first?.durationMinutes ?? Schedule.defaultDurationMinutes
         let additions = pins.filter { !existingPins.contains($0.pin) }
         sequence.append(contentsOf: additions.map { pin in
             Step(pin: pin.pin, durationMinutes: defaultDuration)
@@ -92,7 +105,7 @@ struct ScheduleDraft: Identifiable, Equatable {
 
     mutating func addStep(for pin: PinDTO) {
         guard !sequence.contains(where: { $0.pin == pin.pin }) else { return }
-        let defaultDuration = sequence.first?.durationMinutes ?? Self.defaultDurationMinutes
+        let defaultDuration = sequence.first?.durationMinutes ?? Schedule.defaultDurationMinutes
         sequence.append(Step(pin: pin.pin, durationMinutes: defaultDuration))
     }
 
@@ -114,13 +127,6 @@ struct ScheduleDraft: Identifiable, Equatable {
         sequence.insert(contentsOf: items, at: clampedDestination)
     }
 
-    private static let defaultDurationMinutes = 10
-    static let defaultDays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
-
-    static func orderedDays(from days: [String]) -> [String] {
-        let lowercased = Set(days.map { $0.lowercased() })
-        return defaultDays.filter { lowercased.contains($0.lowercased()) }
-    }
 }
 
 /// Payload used when creating or updating a schedule via the controller API.

--- a/SprinklerMobile/Data/SchedulePersistence.swift
+++ b/SprinklerMobile/Data/SchedulePersistence.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Codable representation of all locally cached schedule state, including
+/// pending deletions that still need to be synchronised with the controller.
+struct SchedulePersistenceState: Codable {
+    var schedules: [Schedule]
+    var pendingDeletionIds: [String]
+    var pendingReorder: [String]?
+
+    init(schedules: [Schedule] = [],
+         pendingDeletionIds: [String] = [],
+         pendingReorder: [String]? = nil) {
+        self.schedules = schedules
+        self.pendingDeletionIds = pendingDeletionIds
+        self.pendingReorder = pendingReorder
+    }
+}
+
+/// Thin wrapper around file-based persistence for offline schedules. The
+/// implementation favours resiliency over strict error propagation so the app
+/// always remains functional even if disk operations fail.
+final class SchedulePersistence {
+    private enum Constants {
+        static let directoryName = "Schedules"
+        static let fileName = "schedules.json"
+    }
+
+    private let queue = DispatchQueue(label: "com.sprinklermobile.schedule-persistence",
+                                      qos: .utility)
+    private let fileManager: FileManager
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private let fileURL: URL?
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        self.encoder = JSONEncoder()
+        self.decoder = JSONDecoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+        self.fileURL = SchedulePersistence.makeFileURL(fileManager: fileManager)
+    }
+
+    func load() -> SchedulePersistenceState {
+        guard let fileURL else { return SchedulePersistenceState() }
+        return queue.sync {
+            do {
+                let data = try Data(contentsOf: fileURL)
+                return try decoder.decode(SchedulePersistenceState.self, from: data)
+            } catch {
+                try? fileManager.removeItem(at: fileURL)
+                return SchedulePersistenceState()
+            }
+        }
+    }
+
+    func save(_ state: SchedulePersistenceState) {
+        guard let fileURL else { return }
+        queue.async {
+            do {
+                let data = try self.encoder.encode(state)
+                try data.write(to: fileURL, options: .atomic)
+            } catch {
+                try? self.fileManager.removeItem(at: fileURL)
+            }
+        }
+    }
+
+    private static func makeFileURL(fileManager: FileManager) -> URL? {
+        guard let baseDirectory = fileManager.urls(for: .applicationSupportDirectory,
+                                                   in: .userDomainMask).first else {
+            return nil
+        }
+        let directory = baseDirectory.appendingPathComponent(Constants.directoryName,
+                                                             isDirectory: true)
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            return directory.appendingPathComponent(Constants.fileName,
+                                                   isDirectory: false)
+        } catch {
+            return nil
+        }
+    }
+}
+

--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -412,7 +412,7 @@ private struct ScheduleSummaryRow: View {
             if !activeNames.isEmpty {
                 secondary.append("Zones: \(activeNames.joined(separator: ", "))")
             }
-            return (run.schedule.name ?? "Schedule", secondary)
+            return (run.schedule.sanitizedName ?? "Schedule", secondary)
         }
 
         if !activeNames.isEmpty {
@@ -424,7 +424,7 @@ private struct ScheduleSummaryRow: View {
 
     private func upcomingRunInfo() -> (primary: String, secondary: [String])? {
         guard let run else { return nil }
-        return (run.schedule.name ?? "Schedule", [detailText(for: run)])
+        return (run.schedule.sanitizedName ?? "Schedule", [detailText(for: run)])
     }
 
     private func detailText(for run: SprinklerStore.ScheduleRun) -> String {

--- a/SprinklerMobile/Views/ScheduleEditorView.swift
+++ b/SprinklerMobile/Views/ScheduleEditorView.swift
@@ -7,7 +7,7 @@ struct ScheduleEditorView: View {
     @State private var timeSelection: Date
     let onSave: (ScheduleDraft) -> Void
 
-    private let dayOptions = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    private let dayOptions = Schedule.defaultDays
 
     private var pinsByNumber: [Int: PinDTO] {
         Dictionary(uniqueKeysWithValues: store.pins.map { ($0.pin, $0) })
@@ -160,7 +160,7 @@ struct ScheduleEditorView: View {
         } else {
             draft.days.append(day)
         }
-        draft.days = ScheduleDraft.orderedDays(from: draft.days)
+        draft.days = Schedule.orderedDays(from: draft.days)
     }
 
     private static func date(from timeString: String) -> Date? {

--- a/SprinklerMobile/Views/ScheduleRowView.swift
+++ b/SprinklerMobile/Views/ScheduleRowView.swift
@@ -2,11 +2,11 @@ import SwiftUI
 
 struct ScheduleRowView: View {
     @EnvironmentObject private var store: SprinklerStore
-    let schedule: ScheduleDTO
+    let schedule: Schedule
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text(schedule.name ?? "Schedule")
+            Text(schedule.sanitizedName ?? "Schedule")
                 .font(.headline)
             HStack(spacing: 12) {
                 if let durationText = durationLabelText {
@@ -14,11 +14,9 @@ struct ScheduleRowView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-                if let start = schedule.startTime {
-                    Label(start, systemImage: "alarm")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                Label(schedule.startTime, systemImage: "alarm")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 if let daysText = daysLabelText {
                     Label(daysText, systemImage: "calendar")
                         .font(.caption2)
@@ -31,22 +29,22 @@ struct ScheduleRowView: View {
     }
 
     private var durationLabelText: String? {
-        let totalDuration = schedule.totalDuration(defaultPins: store.pins)
+        let totalDuration = schedule.totalDurationMinutes
         guard totalDuration > 0 else { return nil }
         return "\(totalDuration) min"
     }
 
     private var daysLabelText: String? {
-        guard let days = schedule.days, !days.isEmpty else {
+        guard !schedule.days.isEmpty else {
             return "Daily"
         }
 
-        let normalized = days.map { $0.lowercased() }
-        let fullWeek = Set(ScheduleDraft.defaultDays.map { $0.lowercased() })
+        let normalized = schedule.days.map { $0.lowercased() }
+        let fullWeek = Set(Schedule.defaultDays.map { $0.lowercased() })
         if Set(normalized) == fullWeek {
             return "Daily"
         }
 
-        return ScheduleDraft.orderedDays(from: days).joined(separator: ", ")
+        return Schedule.orderedDays(from: schedule.days).joined(separator: ", ")
     }
 }

--- a/SprinklerMobileTests/SprinklerStoreTests.swift
+++ b/SprinklerMobileTests/SprinklerStoreTests.swift
@@ -9,7 +9,7 @@ final class SprinklerStoreTests: XCTestCase {
             PinDTO(pin: 4, name: "Front Lawn", isActive: nil, isEnabled: true),
             PinDTO(pin: 5, name: "Back Lawn", isActive: nil, isEnabled: true)
         ]
-        let schedule = ScheduleDTO(
+        let scheduleDTO = ScheduleDTO(
             id: "sequence-midnight",
             name: "Overnight Soak",
             startTime: "23:30",
@@ -22,6 +22,7 @@ final class SprinklerStoreTests: XCTestCase {
             ]
         )
 
+        let schedule = Schedule(dto: scheduleDTO, defaultPins: pins)
         store.configureForTesting(pins: pins, schedules: [schedule])
 
         var calendar = Calendar(identifier: .gregorian)
@@ -45,7 +46,7 @@ final class SprinklerStoreTests: XCTestCase {
             PinDTO(pin: 5, name: "Back Lawn", isActive: nil, isEnabled: true),
             PinDTO(pin: 6, name: "Side Yard", isActive: nil, isEnabled: false)
         ]
-        let legacySchedule = ScheduleDTO(
+        let legacyDTO = ScheduleDTO(
             id: "legacy",
             name: "Legacy",
             startTime: "06:00",
@@ -55,6 +56,7 @@ final class SprinklerStoreTests: XCTestCase {
             sequence: nil
         )
 
+        let legacySchedule = Schedule(dto: legacyDTO, defaultPins: pins)
         store.configureForTesting(pins: pins, schedules: [legacySchedule])
 
         var calendar = Calendar(identifier: .gregorian)


### PR DESCRIPTION
## Summary
- add a domain `Schedule` model plus JSON-backed persistence for offline storage
- update `SprinklerStore` and UI surfaces to use the new model with queued sync to the controller
- extend schedule unit tests to cover the new conversion path

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cee9bded448331acf6cc3972efa75b