### PR TITLE
Adjust text input keyboards and validation behaviors

### DIFF
--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -632,6 +632,8 @@ private struct PinControlRow: View {
             HStack(spacing: 12) {
                 TextField("Minutes", text: $durationBinding)
                     .keyboardType(.numberPad)
+                    .textInputAutocapitalization(.never)
+                    .disableAutocorrection(true)
                     .textFieldStyle(.roundedBorder)
                     .frame(minWidth: 80)
                     .disabled(!isEnabled || isActive)

--- a/SprinklerMobile/Views/PinSettingsView.swift
+++ b/SprinklerMobile/Views/PinSettingsView.swift
@@ -266,6 +266,7 @@ private extension View {
     ) -> some View {
         textInputAutocapitalization(.words)
             .disableAutocorrection(true)
+            .keyboardType(.default)
             .submitLabel(.done)
             .focused(focusBinding, equals: pinID)
             .onSubmit(onSubmit)

--- a/SprinklerMobile/Views/RainStatusView.swift
+++ b/SprinklerMobile/Views/RainStatusView.swift
@@ -377,6 +377,8 @@ private struct RainDelayDurationEditor: View {
                     }
                     TextField("Hours", value: $hours, format: .number)
                         .keyboardType(.numberPad)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
                         .focused($isTextFieldFocused)
                         .id(textFieldID)
                     quickPickRow

--- a/SprinklerMobile/Views/ScheduleEditorView.swift
+++ b/SprinklerMobile/Views/ScheduleEditorView.swift
@@ -72,6 +72,7 @@ struct ScheduleEditorView: View {
         Section("Details") {
             TextField("Name", text: $draft.name)
                 .id("schedule-name-\(draft.id)")
+                .keyboardType(.default)
             LabeledContent("Run Time") {
                 Text("\(totalRuntimeMinutes) min")
                     .font(.body.monospacedDigit())


### PR DESCRIPTION
## Summary
- enforce the default keyboard for editable schedule and pin names to make text entry predictable
- harden numeric duration inputs by disabling autocorrect/capitalization and keeping number pad keyboards across the app

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ceed06b1188331b1d04f7fab98f83f