### PR TITLE
Simplify schedule management to single-run entries

### DIFF
--- a/SprinklerMobile/Data/ScheduleDTO.swift
+++ b/SprinklerMobile/Data/ScheduleDTO.swift
@@ -3,20 +3,36 @@ import Foundation
 struct ScheduleDTO: Codable, Identifiable, Hashable {
     let id: String
     let name: String?
+    let runTimeMinutes: Int?
     let startTime: String?
     let days: [String]?
     let isEnabled: Bool?
-    let durationMinutes: Int?
     let sequence: [ScheduleSequenceItemDTO]?
 
     enum CodingKeys: String, CodingKey {
         case id
         case name
+        case runTimeMinutes = "duration"
         case startTime = "start_time"
         case days
         case isEnabled = "is_enabled"
-        case durationMinutes = "duration"
         case sequence
+    }
+
+    init(id: String,
+         name: String?,
+         runTimeMinutes: Int?,
+         startTime: String?,
+         days: [String]?,
+         isEnabled: Bool?,
+         sequence: [ScheduleSequenceItemDTO]? = nil) {
+        self.id = id
+        self.name = name
+        self.runTimeMinutes = runTimeMinutes
+        self.startTime = startTime
+        self.days = days
+        self.isEnabled = isEnabled
+        self.sequence = sequence
     }
 }
 
@@ -34,35 +50,15 @@ struct ScheduleSequenceItemDTO: Codable, Hashable {
 }
 
 extension ScheduleDTO {
-    /// Resolves the effective sequence for this schedule, falling back to applying the
-    /// legacy single duration to the provided default pins when the backend has not yet
-    /// transitioned to per-pin durations.
-    /// - Parameter defaultPins: Pins sourced from the controller. Enabled pins are
-    ///   preferred, but the method will gracefully fall back to the provided list to
-    ///   ensure every legacy schedule continues to run.
-    /// - Returns: Ordered sequence of pin/duration pairs.
-    func resolvedSequence(defaultPins: [PinDTO]) -> [ScheduleSequenceItemDTO] {
-        if let sequence, !sequence.isEmpty {
-            return sequence
+    /// Resolves the effective runtime for both the modern and legacy payloads.
+    /// - Returns: Total number of minutes the schedule should run.
+    func resolvedRunTimeMinutes() -> Int {
+        if let runTimeMinutes {
+            return max(runTimeMinutes, 0)
         }
 
-        let normalizedDuration = max(durationMinutes ?? 0, 0)
-        guard !defaultPins.isEmpty else { return [] }
-
-        let enabledPins = defaultPins.filter { $0.isEnabled ?? true }
-        let pinsToUse = enabledPins.isEmpty ? defaultPins : enabledPins
-        return pinsToUse.map { pin in
-            ScheduleSequenceItemDTO(pin: pin.pin, durationMinutes: normalizedDuration)
-        }
-    }
-
-    /// Calculates the total runtime for the schedule by summing each sequence step.
-    /// - Parameter defaultPins: Pins used to infer the sequence for legacy payloads.
-    /// - Returns: Total number of minutes the schedule will run.
-    func totalDuration(defaultPins: [PinDTO]) -> Int {
-        resolvedSequence(defaultPins: defaultPins)
-            .reduce(0) { partialResult, item in
-                partialResult + max(item.durationMinutes, 0)
-            }
+        return sequence?.reduce(0) { partialResult, item in
+            partialResult + max(item.durationMinutes, 0)
+        } ?? 0
     }
 }

--- a/SprinklerMobile/Data/ScheduleDraft.swift
+++ b/SprinklerMobile/Data/ScheduleDraft.swift
@@ -1,49 +1,32 @@
 import Foundation
 
 struct ScheduleDraft: Identifiable, Equatable {
-    struct Step: Identifiable, Equatable {
-        var id: UUID
-        var pin: Int
-        var durationMinutes: Int
-
-        init(id: UUID = UUID(), pin: Int, durationMinutes: Int) {
-            self.id = id
-            self.pin = pin
-            self.durationMinutes = durationMinutes
-        }
-    }
-
     var id: String
     var name: String
+    var runTimeMinutes: Int
     var startTime: String
     var days: [String]
     var isEnabled: Bool
-    var sequence: [Step]
 
     init(id: String = UUID().uuidString,
          name: String = "",
+         runTimeMinutes: Int = Schedule.defaultDurationMinutes,
          startTime: String = Schedule.defaultStartTime,
          days: [String] = Schedule.defaultDays,
          isEnabled: Bool = true,
-         sequence: [Step] = [],
-         pins: [PinDTO] = []) {
+         pins _: [PinDTO] = []) {
         self.id = id
         self.name = name
+        self.runTimeMinutes = max(runTimeMinutes, 0)
         self.startTime = startTime
         self.days = Schedule.orderedDays(from: days)
         self.isEnabled = isEnabled
-        if sequence.isEmpty {
-            let resolvedPins = pins.filter { $0.isEnabled ?? true }
-            let seeds = resolvedPins.isEmpty ? pins : resolvedPins
-            self.sequence = seeds.map { Step(pin: $0.pin, durationMinutes: Schedule.defaultDurationMinutes) }
-        } else {
-            self.sequence = sequence
-        }
     }
 
-    init(schedule: Schedule, pins: [PinDTO] = []) {
+    init(schedule: Schedule, pins _: [PinDTO] = []) {
         self.id = schedule.id
         self.name = schedule.name
+        self.runTimeMinutes = max(schedule.runTimeMinutes, 0)
         self.startTime = schedule.startTime
         if schedule.days.isEmpty {
             self.days = Schedule.defaultDays
@@ -51,82 +34,27 @@ struct ScheduleDraft: Identifiable, Equatable {
             self.days = Schedule.orderedDays(from: schedule.days)
         }
         self.isEnabled = schedule.isEnabled
-        if schedule.sequence.isEmpty, let firstPin = pins.first {
-            self.sequence = [Step(pin: firstPin.pin,
-                                   durationMinutes: Schedule.defaultDurationMinutes)]
-        } else {
-            self.sequence = schedule.sequence.map { item in
-                Step(pin: item.pin, durationMinutes: item.durationMinutes)
-            }
-        }
     }
 
     var payload: ScheduleWritePayload {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        let sanitizedSequence = sequence.map { step -> Step in
-            var copy = step
-            copy.durationMinutes = max(copy.durationMinutes, 0)
-            return copy
-        }
-        let fallbackDuration = sanitizedSequence.first?.durationMinutes ?? Schedule.defaultDurationMinutes
         return ScheduleWritePayload(name: trimmedName.isEmpty ? nil : trimmedName,
-                                    durationMinutes: fallbackDuration,
+                                    durationMinutes: max(runTimeMinutes, 0),
                                     startTime: startTime,
                                     days: days.isEmpty ? nil : Schedule.orderedDays(from: days),
-                                    isEnabled: isEnabled,
-                                    sequence: sanitizedSequence.map { step in
-                                        ScheduleWritePayload.Step(pin: step.pin,
-                                                                  durationMinutes: step.durationMinutes)
-                                    })
+                                    isEnabled: isEnabled)
     }
 
     var schedule: Schedule {
-        let sanitizedSequence = sequence.map { step in
-            Schedule.Step(pin: step.pin, durationMinutes: max(step.durationMinutes, 0))
-        }
         return Schedule(id: id,
                          name: name,
+                         runTimeMinutes: max(runTimeMinutes, 0),
                          startTime: startTime,
                          days: days,
                          isEnabled: isEnabled,
-                         sequence: sanitizedSequence,
                          lastModified: Date(),
                          lastSyncedAt: nil)
     }
-
-    mutating func addSteps(for pins: [PinDTO]) {
-        let existingPins = Set(sequence.map(\.pin))
-        let defaultDuration = sequence.first?.durationMinutes ?? Schedule.defaultDurationMinutes
-        let additions = pins.filter { !existingPins.contains($0.pin) }
-        sequence.append(contentsOf: additions.map { pin in
-            Step(pin: pin.pin, durationMinutes: defaultDuration)
-        })
-    }
-
-    mutating func addStep(for pin: PinDTO) {
-        guard !sequence.contains(where: { $0.pin == pin.pin }) else { return }
-        let defaultDuration = sequence.first?.durationMinutes ?? Schedule.defaultDurationMinutes
-        sequence.append(Step(pin: pin.pin, durationMinutes: defaultDuration))
-    }
-
-    mutating func removeSteps(at offsets: IndexSet) {
-        for offset in offsets.sorted(by: >) {
-            guard sequence.indices.contains(offset) else { continue }
-            sequence.remove(at: offset)
-        }
-    }
-
-    mutating func moveSteps(from offsets: IndexSet, to destination: Int) {
-        let items = offsets.compactMap { index -> Step? in
-            guard sequence.indices.contains(index) else { return nil }
-            return sequence[index]
-        }
-        removeSteps(at: offsets)
-        let adjustedDestination = destination - offsets.filter { $0 < destination }.count
-        let clampedDestination = max(0, min(adjustedDestination, sequence.count))
-        sequence.insert(contentsOf: items, at: clampedDestination)
-    }
-
 }
 
 /// Payload used when creating or updating a schedule via the controller API.
@@ -136,17 +64,6 @@ struct ScheduleWritePayload: Encodable {
     let startTime: String
     let days: [String]?
     let isEnabled: Bool
-    let sequence: [Step]
-
-    struct Step: Encodable, Equatable {
-        let pin: Int
-        let durationMinutes: Int
-
-        enum CodingKeys: String, CodingKey {
-            case pin
-            case durationMinutes = "duration"
-        }
-    }
 
     enum CodingKeys: String, CodingKey {
         case name
@@ -154,6 +71,5 @@ struct ScheduleWritePayload: Encodable {
         case startTime = "start_time"
         case days
         case isEnabled = "is_enabled"
-        case sequence
     }
 }

--- a/SprinklerMobile/Views/ScheduleRowView.swift
+++ b/SprinklerMobile/Views/ScheduleRowView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct ScheduleRowView: View {
-    @EnvironmentObject private var store: SprinklerStore
     let schedule: Schedule
 
     var body: some View {

--- a/SprinklerMobileTests/SprinklerStoreTests.swift
+++ b/SprinklerMobileTests/SprinklerStoreTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @MainActor
 final class SprinklerStoreTests: XCTestCase {
-    func testSequenceScheduleTotalsAcrossMidnight() {
+    func testScheduleRunTimeAcrossMidnight() {
         let store = makeStore()
         let pins = [
             PinDTO(pin: 4, name: "Front Lawn", isActive: nil, isEnabled: true),
@@ -12,10 +12,10 @@ final class SprinklerStoreTests: XCTestCase {
         let scheduleDTO = ScheduleDTO(
             id: "sequence-midnight",
             name: "Overnight Soak",
+            runTimeMinutes: nil,
             startTime: "23:30",
             days: ["Mon"],
             isEnabled: true,
-            durationMinutes: nil,
             sequence: [
                 ScheduleSequenceItemDTO(pin: 4, durationMinutes: 45),
                 ScheduleSequenceItemDTO(pin: 5, durationMinutes: 90)
@@ -39,7 +39,7 @@ final class SprinklerStoreTests: XCTestCase {
         XCTAssertEqual(run.endDate, expectedEnd)
     }
 
-    func testLegacyDurationExpandsToAllPins() {
+    func testRunTimeUsesDirectDuration() {
         let store = makeStore()
         let pins = [
             PinDTO(pin: 4, name: "Front Lawn", isActive: nil, isEnabled: true),
@@ -49,10 +49,10 @@ final class SprinklerStoreTests: XCTestCase {
         let legacyDTO = ScheduleDTO(
             id: "legacy",
             name: "Legacy",
+            runTimeMinutes: 15,
             startTime: "06:00",
             days: ["Tue"],
             isEnabled: true,
-            durationMinutes: 15,
             sequence: nil
         )
 
@@ -68,7 +68,7 @@ final class SprinklerStoreTests: XCTestCase {
             return XCTFail("Expected legacy schedule run to be generated")
         }
 
-        let expectedEnd = calendar.date(from: DateComponents(year: 2024, month: 5, day: 7, hour: 6, minute: 30))!
+        let expectedEnd = calendar.date(from: DateComponents(year: 2024, month: 5, day: 7, hour: 6, minute: 15))!
         XCTAssertEqual(run.startDate, calendar.date(from: DateComponents(year: 2024, month: 5, day: 7, hour: 6, minute: 0)))
         XCTAssertEqual(run.endDate, expectedEnd)
     }


### PR DESCRIPTION
## Summary
- replace zone-sequence schedules with a flat runtime-based Schedule model and payload
- streamline the schedule editor UI for simple runtime entry and day selection
- adjust schedule list rendering and tests to match the new simplified data contract

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ceee05b5d88331beb95e1b48a8afa4