### PR TITLE
Integrate discovery into connection settings

### DIFF
--- a/SprinklerMobile/Utils/ControllerConfig.swift
+++ b/SprinklerMobile/Utils/ControllerConfig.swift
@@ -15,6 +15,12 @@ enum ControllerConfig {
     /// Default TCP port exposed by the controller web service.
     static let defaultPort = 8000
 
+    /// Feature toggle that determines whether Bonjour discovery is surfaced in the UI.
+    ///
+    /// Keeping the switch centralised makes it easy to disable discovery in builds where
+    /// Bonjour APIs are not available (for example, unit tests running on Linux).
+    static let isDiscoveryEnabled = true
+
     /// Canonical base URL used for new installations before the user customises the address.
     static var defaultBaseURL: URL {
         var components = URLComponents()


### PR DESCRIPTION
## Summary
- combine manual controller URL entry, connection testing, and discovery results in the primary connection settings card
- gate Bonjour discovery behind a shared feature toggle and only start the browser when enabled
- surface recent connection logs alongside discovery results while continuing to persist selected URLs

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cef1238efc8331840ac562292496ae