### PR TITLE
Add system information card to settings tab

### DIFF
--- a/SprinklerMobile/Stores/ConnectivityStore.swift
+++ b/SprinklerMobile/Stores/ConnectivityStore.swift
@@ -35,6 +35,10 @@ final class ConnectivityStore: ObservableObject {
     @Published private(set) var recentLogs: [ConnectionTestLog]
     /// Inline validation error surfaced underneath the controller address field.
     @Published var validationMessage: String?
+    /// Timestamp describing when the sprinkler controller last responded successfully.
+    var lastSuccessfulConnectionDate: Date? {
+        recentLogs.first(where: { $0.outcome == .success })?.date
+    }
 
     private let checker: ConnectivityChecking
     private let defaults: UserDefaults

--- a/SprinklerMobile/Utils/ControllerConfig.swift
+++ b/SprinklerMobile/Utils/ControllerConfig.swift
@@ -37,4 +37,15 @@ enum ControllerConfig {
 
     /// String representation of the canonical base URL used by default in the UI.
     static var defaultBaseAddress: String { defaultBaseURL.absoluteString }
+
+    /// Canonical documentation URL that surfaces the README instructions within the app.
+    static var documentationURL: URL {
+        // The URL is stored as a computed property to avoid static initialization crashes
+        // if the string ever becomes invalid. Failing fast in development keeps the
+        // application honest without impacting release stability.
+        guard let url = URL(string: "https://github.com/tybuell/SprinklerApp/blob/main/README.md") else {
+            preconditionFailure("Invalid documentation URL configuration")
+        }
+        return url
+    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated settings card that surfaces the app version, build, and last successful controller connection
- expose the controller documentation link in ControllerConfig and surface it in the new card
- extend ConnectivityStore with a helper for the last successful connection timestamp and add absolute timestamp formatting

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cef318f33483319d7aa73679438d71