### PR TITLE
Gracefully queue offline changes and surface errors

### DIFF
--- a/SprinklerMobile/Views/BannerMessageView.swift
+++ b/SprinklerMobile/Views/BannerMessageView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// Lightweight banner used to surface persistent informational and error messages above the dashboard content.
+struct BannerMessageView: View {
+    enum Style {
+        case error
+        case info
+    }
+
+    let style: Style
+    let message: String
+    var onDismiss: (() -> Void)?
+
+    private var iconName: String {
+        switch style {
+        case .error:
+            return "exclamationmark.triangle.fill"
+        case .info:
+            return "info.circle.fill"
+        }
+    }
+
+    private var accentColor: Color {
+        switch style {
+        case .error:
+            return .appDanger
+        case .info:
+            return .appAccentPrimary
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: iconName)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(accentColor)
+                .accessibilityHidden(true)
+
+            Text(message)
+                .font(.appBody)
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 8)
+
+            if let onDismiss {
+                Button {
+                    onDismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(8)
+                        .background(
+                            Circle()
+                                .fill(Color.white.opacity(0.15))
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss message")
+            }
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 16)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color.appSecondaryBackground.opacity(0.85))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(accentColor.opacity(0.35), lineWidth: 1)
+        )
+        .shadow(color: Color.appShadow.opacity(0.08), radius: 8, x: 0, y: 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(message)
+    }
+}

--- a/SprinklerMobile/Views/DashboardView.swift
+++ b/SprinklerMobile/Views/DashboardView.swift
@@ -35,6 +35,19 @@ struct DashboardView: View {
 
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 24) {
+                        if let errorMessage = sprinklerStore.connectionErrorMessage,
+                           !errorMessage.isEmpty {
+                            BannerMessageView(style: .error,
+                                              message: errorMessage,
+                                              onDismiss: { sprinklerStore.dismissErrorMessage() })
+                        }
+
+                        if let syncMessage = sprinklerStore.pendingSyncMessage {
+                            BannerMessageView(style: .info,
+                                              message: syncMessage,
+                                              onDismiss: nil)
+                        }
+
                         connectivityStatusBadge
                         ledStatusCard
                         DashboardCard(title: "Schedule Summary") {


### PR DESCRIPTION
## Summary
- add connection error tracking and a pending sync queue to the sprinkler store so offline changes can be retried
- update pin, rain, and automation actions to enqueue requests when unreachable while preserving local UI feedback
- surface controller errors and queued syncs in the dashboard via a reusable banner message view

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cef78c5a50833199f880a3bc9b954b