### PR TITLE
Add CI workflow for Swift package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "work"]
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Ensure required files are present
+        run: |
+          test -f Package.swift
+          test -f README.md
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: "5.8"
+
+      - name: Build (treat warnings as errors)
+        run: swift build -Xswiftc -warnings-as-errors
+
+      - name: Run tests (treat warnings as errors)
+        run: swift test -Xswiftc -warnings-as-errors


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that verifies required project files are present
- build the Swift package with warnings treated as errors
- run the test suite with the same strict warning policy

## Testing
- swift test -Xswiftc -warnings-as-errors

------
https://chatgpt.com/codex/tasks/task_e_68cf01888cd483318e86a495f70fd664