### PR TITLE
Update gitignore to exclude SwiftPM artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,13 @@ xcuserdata/
 DerivedData/
 build/
 .build/
+.swiftpm/
+
+# Swift Package Manager dependency resolution
+Package.resolved
+
+# Playgrounds and other transient developer artifacts
+*.playground
 
 # macOS metadata files
 .DS_Store

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>


### PR DESCRIPTION
## Summary
- expand the repository `.gitignore` to exclude SwiftPM build artifacts, Package.resolved, and playground files
- remove the previously tracked `.swiftpm` workspace artifact so derived data stays out of version control

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf02bbd7cc833185d97533d0970109