### PR TITLE
Fix CI by pinning Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-test:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- pin the GitHub Actions runner to ubuntu-22.04 so the Swift setup action uses a supported OS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf0860d6c48331b936d7175b6a392e