### PR TITLE
Fix rain delay accessibility hint string

### DIFF
--- a/SprinklerMobile/Views/RainStatusView.swift
+++ b/SprinklerMobile/Views/RainStatusView.swift
@@ -152,7 +152,7 @@ struct RainStatusView: View {
             }
         }
         .toggleStyle(.switch)
-        .accessibilityHint("Double tap to \(rain?.isActive == true ? \"end\" : \"start\") a temporary rain delay.")
+        .accessibilityHint(manualToggleAccessibilityHint)
     }
 
     private var manualDurationButton: some View {
@@ -200,6 +200,11 @@ struct RainStatusView: View {
 
     private var showAutomationToggle: Bool {
         hasAutomationConfiguration
+    }
+
+    private var manualToggleAccessibilityHint: String {
+        let actionVerb = rain?.isActive == true ? "end" : "start"
+        return "Double tap to \(actionVerb) a temporary rain delay."
     }
 
     private var hasAutomationConfiguration: Bool {


### PR DESCRIPTION
## Summary
- replace the inline manual rain delay accessibility hint with a helper property
- reuse the helper to compose the dynamic action verb without escaping issues

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf09c32cac8331b1776a54eaf5adcd