### PR TITLE
Fix RainStatusView Section initialiser for iOS 18

### DIFF
--- a/SprinklerMobile/Views/RainStatusView.swift
+++ b/SprinklerMobile/Views/RainStatusView.swift
@@ -370,7 +370,7 @@ private struct RainDelayDurationEditor: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section("Delay Length") {
+                Section {
                     Stepper(value: $hours, in: validRange) {
                         HStack {
                             Text("Duration")
@@ -387,6 +387,8 @@ private struct RainDelayDurationEditor: View {
                         .focused($isTextFieldFocused)
                         .id(textFieldID)
                     quickPickRow
+                } header: {
+                    Text("Delay Length")
                 } footer: {
                     Text("All watering schedules will remain paused for the selected duration.")
                         .font(.appCaption)


### PR DESCRIPTION
## Summary
- switch the manual rain delay editor form section to use the header/content/footer initializer so it compiles with modern SDKs

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf0b731738833188aa20ff94f4f7e3