### PR TITLE
Include BannerMessageView in iOS target

### DIFF
--- a/Sprink.xcodeproj/project.pbxproj
+++ b/Sprink.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		621360F32E7C8C730094E4D2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 621360F22E7C8C730094E4D2 /* Assets.xcassets */; };
 		6251FB8F2E7C7DCF001856FD /* RainDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB662E7C7DCF001856FD /* RainDTO.swift */; };
 		6251FB902E7C7DCF001856FD /* ConnectivityBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB7E2E7C7DCF001856FD /* ConnectivityBadgeView.swift */; };
+                3D597EEC80584CEFB6E625EA /* BannerMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35B35E7822DC4DCA8899B282 /* BannerMessageView.swift */; };
                 6251FB912E7C7DCF001856FD /* SkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB782E7C7DCF001856FD /* SkeletonView.swift */; };
                 6251FB932E7C7DCF001856FD /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB642E7C7DCF001856FD /* HTTPClient.swift */; };
                 6251FB942E7C7DCF001856FD /* BonjourDiscoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6251FB712E7C7DCF001856FD /* BonjourDiscoveryService.swift */; };
@@ -108,6 +109,7 @@
 		6251FB812E7C7DCF001856FD /* PinsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinsListView.swift; sourceTree = "<group>"; };
 		6251FB822E7C7DCF001856FD /* RainStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RainStatusView.swift; sourceTree = "<group>"; };
 		6251FB832E7C7DCF001856FD /* ScheduleEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleEditorView.swift; sourceTree = "<group>"; };
+		35B35E7822DC4DCA8899B282 /* BannerMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerMessageView.swift; sourceTree = "<group>"; };
 		6251FB842E7C7DCF001856FD /* ScheduleRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleRowView.swift; sourceTree = "<group>"; };
 		6251FB852E7C7DCF001856FD /* SchedulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulesView.swift; sourceTree = "<group>"; };
 		6251FB862E7C7DCF001856FD /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -245,6 +247,7 @@
 		6251FB872E7C7DCF001856FD /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				35B35E7822DC4DCA8899B282 /* BannerMessageView.swift */,
 				6251FB7E2E7C7DCF001856FD /* ConnectivityBadgeView.swift */,
 				6251FB7F2E7C7DCF001856FD /* DashboardView.swift */,
 				6251FB802E7C7DCF001856FD /* PinRowView.swift */,
@@ -410,6 +413,7 @@
 			files = (
 				6251FB8F2E7C7DCF001856FD /* RainDTO.swift in Sources */,
 				6251FB902E7C7DCF001856FD /* ConnectivityBadgeView.swift in Sources */,
+				3D597EEC80584CEFB6E625EA /* BannerMessageView.swift in Sources */,
 				6251FB912E7C7DCF001856FD /* SkeletonView.swift in Sources */,
 				6251FB932E7C7DCF001856FD /* HTTPClient.swift in Sources */,
 				6208747D2E7DF2C00062F269 /* Color+Theme.swift in Sources */,


### PR DESCRIPTION
## Summary
- add BannerMessageView.swift to the Sprink target's build files and file references so the dashboard can compile the banner component
- include the banner view in the Views group so it appears in the project navigator

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf0db328d48331a0515efe1f352cf8