### PR TITLE
Handle Bonjour configuration error and tidy schedule merge

### DIFF
--- a/SprinklerMobile/Services/BonjourDiscoveryService.swift
+++ b/SprinklerMobile/Services/BonjourDiscoveryService.swift
@@ -267,6 +267,8 @@ private extension BonjourDiscoveryService {
             return "The discovery request was malformed."
         case .cancelledError:
             return "Discovery was cancelled before finishing."
+        case .missingRequiredConfigurationError:
+            return "The network configuration for discovery is incomplete."
         case .invalidError:
             return "The discovery request was invalid."
         case .timeoutError:

--- a/SprinklerMobile/Stores/SprinklerStore.swift
+++ b/SprinklerMobile/Stores/SprinklerStore.swift
@@ -1071,7 +1071,7 @@ final class SprinklerStore: ObservableObject {
             var normalized = remote
             normalized.lastModified = now
             normalized.lastSyncedAt = now
-            if var local = localById.removeValue(forKey: remote.id) {
+            if let local = localById.removeValue(forKey: remote.id) {
                 if local.needsSync {
                     merged[local.id] = local
                     continue


### PR DESCRIPTION
## Summary
- add an explicit message for the Bonjour missing configuration error so the switch remains exhaustive
- convert the temporary schedule merge binding to a constant to satisfy Swift's immutability warning

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf1ef924fc833190ce821567c462cc