### PR TITLE
Ensure default GPIO pins stay visible on dashboard

### DIFF
--- a/SprinklerMobile/Stores/SprinklerStore.swift
+++ b/SprinklerMobile/Stores/SprinklerStore.swift
@@ -1050,11 +1050,14 @@ final class SprinklerStore: ObservableObject {
             if let existing = catalogOverrides[pinNumber] {
                 return existing
             }
-            // Backend did not report this pin, so surface it as a disabled placeholder.
+            // Backend did not report this pin. Surface a placeholder that
+            // remains enabled so the dashboard still lists every GPIO the
+            // hardware supports, preserving the legacy behaviour where all
+            // default zones were visible even before the Pi responded.
             return PinDTO(pin: pinNumber,
                           name: nil,
-                          isActive: nil,
-                          isEnabled: false)
+                          isActive: false,
+                          isEnabled: true)
         }
 
         // Append any non-catalog pins so the full server response remains visible.


### PR DESCRIPTION
## Summary
- ensure catalog placeholder pins remain enabled so the dashboard always lists every GPIO when the controller omits metadata
- default placeholder pins now report inactive/visible state to maintain legacy behaviour

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf200ce33483318504c5dc32cf4bd0