### PR TITLE
Expand default sprinkler pin placeholders

### DIFF
--- a/SprinklerMobile/Data/PinDTO.swift
+++ b/SprinklerMobile/Data/PinDTO.swift
@@ -27,14 +27,27 @@ extension PinDTO {
     /// provide a realistic placeholder list before the mobile client downloads
     /// live configuration data from the backend.
     static let defaultSprinklerCatalog: [PinDTO] = [
-        PinDTO(pin: 4, name: "Zone 1", isActive: false, isEnabled: true),
-        PinDTO(pin: 17, name: "Zone 2", isActive: false, isEnabled: true),
-        PinDTO(pin: 27, name: "Zone 3", isActive: false, isEnabled: true),
-        PinDTO(pin: 22, name: "Zone 4", isActive: false, isEnabled: true),
-        PinDTO(pin: 5, name: "Zone 5", isActive: false, isEnabled: true),
-        PinDTO(pin: 6, name: "Zone 6", isActive: false, isEnabled: true),
+        // The order mirrors the Raspberry Pi mapping defined in
+        // `backend/app.py` and `backend/sprinkler_service.py`. Keeping the
+        // sequence identical ensures the iOS placeholders line up with the
+        // physical relay wiring (zone 1 = GPIO 12, ..., zone 16 = GPIO 4)
+        // while the device waits for a live `/status` payload.
+        PinDTO(pin: 12, name: "Zone 1", isActive: false, isEnabled: true),
+        PinDTO(pin: 16, name: "Zone 2", isActive: false, isEnabled: true),
+        PinDTO(pin: 20, name: "Zone 3", isActive: false, isEnabled: true),
+        PinDTO(pin: 21, name: "Zone 4", isActive: false, isEnabled: true),
+        PinDTO(pin: 26, name: "Zone 5", isActive: false, isEnabled: true),
+        PinDTO(pin: 19, name: "Zone 6", isActive: false, isEnabled: true),
         PinDTO(pin: 13, name: "Zone 7", isActive: false, isEnabled: true),
-        PinDTO(pin: 19, name: "Zone 8", isActive: false, isEnabled: true)
+        PinDTO(pin: 6, name: "Zone 8", isActive: false, isEnabled: true),
+        PinDTO(pin: 5, name: "Zone 9", isActive: false, isEnabled: true),
+        PinDTO(pin: 11, name: "Zone 10", isActive: false, isEnabled: true),
+        PinDTO(pin: 9, name: "Zone 11", isActive: false, isEnabled: true),
+        PinDTO(pin: 10, name: "Zone 12", isActive: false, isEnabled: true),
+        PinDTO(pin: 22, name: "Zone 13", isActive: false, isEnabled: true),
+        PinDTO(pin: 27, name: "Zone 14", isActive: false, isEnabled: true),
+        PinDTO(pin: 17, name: "Zone 15", isActive: false, isEnabled: true),
+        PinDTO(pin: 4, name: "Zone 16", isActive: false, isEnabled: true)
     ]
 
     /// Convenience accessor that exposes just the safe-to-drive GPIO pin numbers


### PR DESCRIPTION
## Summary
- expand the default PinDTO sprinkler catalog to all 16 GPIOs used by the Raspberry Pi controller
- document that the placeholder order now mirrors the backend pin mapping so zones align before the first refresh

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68cf34b9068c83319e9dcdb7c7ca505a