### PR TITLE
Fix manual zone runs shutting off prematurely

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The authenticated FastAPI backend now exposes a RESTful surface that matches the
 | `POST` | `/zone/on/{zone}` | Starts a zone immediately for the supplied minutes. |
 | `POST` | `/zone/off/{zone}` | Stops a running zone. |
 
-The legacy compatibility routes (`/status`, `/api/pins`, `/api/pin/{pin}`) remain available so older builds keep working during rollout.
+The legacy compatibility routes (`/status`, `/api/pins`, `/api/pin/{pin}`) remain available so older builds keep working during rollout. When using `POST /api/pin/{pin}/on` you can provide an optional JSON payload such as `{"minutes": 10}` to request a specific runtime; omitting the body preserves the default 30-minute duration.
 
 Schedules persist to `/srv/sprinkler-controller/state/schedules.json` and are replayed automatically on the Raspberry Pi. Each schedule triggers at its configured start time on matching weekdays, drives the referenced GPIO pins sequentially, and respects active rain delays so you never water during a manual lockout.
 

--- a/SprinklerMobile/Data/APIClient.swift
+++ b/SprinklerMobile/Data/APIClient.swift
@@ -75,9 +75,21 @@ actor APIClient {
         _ = try await perform(endpoint)
     }
 
-    func setPin(_ pin: Int, on: Bool) async throws {
+    func setPin(_ pin: Int, on: Bool, minutes: Int? = nil) async throws {
+        struct StartPinPayload: Encodable {
+            let minutes: Int
+        }
+
+        let body: AnyEncodable?
+        if on, let minutes {
+            body = AnyEncodable(StartPinPayload(minutes: minutes))
+        } else {
+            body = nil
+        }
+
         let endpoint = Endpoint<EmptyResponse>(path: "/api/pin/\(pin)/\(on ? "on" : "off")",
                                                method: .post,
+                                               body: body,
                                                fallbackToEmptyBody: true)
         _ = try await perform(endpoint)
     }

--- a/backend/sprinkler_service.py
+++ b/backend/sprinkler_service.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pigpio
-from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi import Body, Depends, FastAPI, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
@@ -734,9 +734,12 @@ async def api_pins_compat():
 
 
 @app.post("/api/pin/{pin}/on", dependencies=[Depends(require_token)])
-async def api_pin_on_compat(pin: int):
+async def api_pin_on_compat(
+    pin: int,
+    payload: StartZoneRequest = Body(default=StartZoneRequest()),
+):
     zone = _zone_for_pin(pin)
-    return await start_zone(zone, StartZoneRequest(minutes=DEFAULT_RUNTIME_MINUTES))  # type: ignore[arg-type]
+    return await start_zone(zone, payload)  # type: ignore[arg-type]
 
 
 @app.post("/api/pin/{pin}/off", dependencies=[Depends(require_token)])


### PR DESCRIPTION
## Summary
- allow `/api/pin/{pin}/on` compatibility endpoint to honor an optional minutes payload
- update the iOS API client and store so timed runs send the desired duration to the controller and rely on the backend timer
- document the new JSON body support in the README

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf396dc10483319aa6d8885e7397ee