### PR TITLE
Add continuous sprinkler status polling

### DIFF
--- a/SprinklerMobile/SprinklerMobileApp.swift
+++ b/SprinklerMobile/SprinklerMobileApp.swift
@@ -17,6 +17,9 @@ struct SprinklerMobileApp: App {
 }
 
 private struct RootView: View {
+    @EnvironmentObject private var sprinklerStore: SprinklerStore
+    @Environment(\.scenePhase) private var scenePhase
+
     var body: some View {
         TabView {
             DashboardView()
@@ -30,5 +33,16 @@ private struct RootView: View {
                 }
         }
         .tint(Color.appAccentPrimary)
+        .task { sprinklerStore.beginStatusPolling() }
+        .onChange(of: scenePhase) { _, newPhase in
+            switch newPhase {
+            case .active:
+                sprinklerStore.beginStatusPolling()
+            case .background, .inactive:
+                sprinklerStore.endStatusPolling()
+            @unknown default:
+                sprinklerStore.endStatusPolling()
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable status fetch helper that supports interactive refreshes and silent background updates
- introduce a polling loop in `SprinklerStore` and hook it into the app lifecycle so pin state stays current
- request an immediate status sync after manual pin toggles to confirm hardware state in the UI

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf3e2a0e60833195f5b70404019679